### PR TITLE
add: api key for client api

### DIFF
--- a/client-web-panel/pages/_app.js
+++ b/client-web-panel/pages/_app.js
@@ -15,14 +15,14 @@ import '@/styles/globals.css'
 import '@/styles/rtl.css'
 // Dark Mode Styles
 import '@/styles/dark.css'
-import "@/public/fonts/Yekan-Bakh-Pro/Font-Family/Webfonts/fontface.css";
+
 // Theme Styles
 import theme from '@/styles/theme'
 
 import {ThemeProvider, CssBaseline} from "@mui/material";
 import Layout from "@/components/_App/Layout";
 import {Provider} from 'react-redux';
-import {store, Persistor} from '../redux/store'; // import store and persistor from your store file
+import {store, Persistor} from '@/redux/store'; // import store and persistor from your store file
 import {PersistGate} from 'redux-persist/integration/react';
 import I18nProvider from 'next-translate/I18nProvider';
 import loadNamespaces from 'next-translate/loadNamespaces';

--- a/mini-app/src/app/api/client/v1/public/login/route.ts
+++ b/mini-app/src/app/api/client/v1/public/login/route.ts
@@ -1,52 +1,55 @@
 import { z } from "zod";
-import { NextResponse } from "next/server";  // Fixed to use NextResponse
+import { NextResponse } from "next/server";
 import { redisTools } from "@/lib/redisTools";
 import { usersDB } from "@/server/db/users";
 import jwt from "jsonwebtoken";
 
 const JWT_SECRET = process.env.CLIENT_API_JWT_SECRET!;
+const FIXED_API_KEY = process.env.CLIENT_API_FIXED_KEY!; // Add your fixed API key here
+const FIXED_USER = process.env.CLIENT_API_FIXED_USER!; // Add your fixed API key here
+const FIXED_ORGANIZER = process.env.CLIENT_API_FIXED_ORGANIZER!; // Add your fixed API key here
 
 // Define error codes for consistent error responses
 const ERROR_CODES = {
-  METHOD_NOT_ALLOWED: {
-    code: "METHOD_NOT_ALLOWED",
-    message: "Method not allowed.",
-  },
-  VALIDATION_FAILED: {
-    code: "VALIDATION_FAILED",
-    message: "Invalid input parameters.",
-  },
-  OTP_INVALID: { code: "OTP_INVALID", message: "Invalid OTP." },
-  USER_NOT_FOUND: { code: "USER_NOT_FOUND", message: "User not found." },
-  OTP_DELETION_FAILED: {
-    code: "OTP_DELETION_FAILED",
-    message: "Error deleting OTP from cache.",
-  },
-  UNKNOWN_ERROR: {
-    code: "UNKNOWN_ERROR",
-    message: "An unknown error occurred.",
-  },
+    METHOD_NOT_ALLOWED: {
+        code: "METHOD_NOT_ALLOWED",
+        message: "Method not allowed.",
+    },
+    VALIDATION_FAILED: {
+        code: "VALIDATION_FAILED",
+        message: "Invalid input parameters.",
+    },
+    OTP_INVALID: { code: "OTP_INVALID", message: "Invalid OTP." },
+    USER_NOT_FOUND: { code: "USER_NOT_FOUND", message: "User not found." },
+    OTP_DELETION_FAILED: {
+        code: "OTP_DELETION_FAILED",
+        message: "Error deleting OTP from cache.",
+    },
+    UNKNOWN_ERROR: {
+        code: "UNKNOWN_ERROR",
+        message: "An unknown error occurred.",
+    },
 };
 
 // Define success codes
 const SUCCESS_CODES = {
-  LOGIN_SUCCESS: {
-    code: "LOGIN_SUCCESS",
-    message: "Login successful. JWT generated.",
-  },
+    LOGIN_SUCCESS: {
+        code: "LOGIN_SUCCESS",
+        message: "Login successful. JWT generated.",
+    },
 };
 
 // Zod schema for validating the request body (now using organizerId and userId)
 const loginSchema = z.object({
-  organizerId: z
-      .string()
-      .min(2)
-      .regex(/^@[a-zA-Z0-9_]{5,}$/, "Invalid organizer Telegram username format"),
-  userId: z
-      .string()
-      .min(2)
-      .regex(/^@[a-zA-Z0-9_]{5,}$/, "Invalid user Telegram username format"),
-  loginCode: z.string(),
+    organizerId: z
+        .string()
+        .min(2)
+        .regex(/^@[a-zA-Z0-9_]{5,}$/, "Invalid organizer Telegram username format"),
+    userId: z
+        .string()
+        .min(2)
+        .regex(/^@[a-zA-Z0-9_]{5,}$/, "Invalid user Telegram username format"),
+    loginCode: z.string(),
 });
 
 /**
@@ -127,106 +130,133 @@ const loginSchema = z.object({
  *                       description: Error message.
  */
 export async function POST(req: Request) {
-  if (req.method === "OPTIONS") {
-    return NextResponse.json(null, { status: 204 }); // Handle preflight requests
-  }
-
-  if (req.method !== "POST") {
-    return NextResponse.json(
-        { success: false, error: ERROR_CODES.METHOD_NOT_ALLOWED },
-        { status: 405 }
-    );
-  }
-
-  try {
-    const body = await req.json(); // Parse the request body
-    const parsedBody = loginSchema.safeParse(body);
-
-    if (!parsedBody.success) {
-      return NextResponse.json(
-          {
-            success: false,
-            error: ERROR_CODES.VALIDATION_FAILED,
-            details: parsedBody.error.errors.map((err) => ({
-              path: err.path,
-              message: err.message,
-            })),
-          },
-          { status: 400 }
-      );
+    if (req.method === "OPTIONS") {
+        return NextResponse.json(null, { status: 204 }); // Handle preflight requests
     }
 
-    const { organizerId, userId, loginCode } = parsedBody.data;
-
-    // Fetch OTP from Redis and validate using both organizerId and userId
-    const cachedCode = await redisTools.getCache(
-        `${redisTools.cacheKeys.authApiOtp}${organizerId}:${userId}`
-    );
-
-    if (!cachedCode || cachedCode !== loginCode) {
-      return NextResponse.json(
-          { success: false, error: ERROR_CODES.OTP_INVALID },
-          { status: 401 }
-      );
+    if (req.method !== "POST") {
+        return NextResponse.json(
+            { success: false, error: ERROR_CODES.METHOD_NOT_ALLOWED },
+            { status: 405 }
+        );
     }
 
-    // Fetch the user from the database using the userId (Telegram username)
-    const user = await usersDB.selectUserByUsername(userId.replace("@", ""));
-
-    if (!user) {
-      return NextResponse.json(
-          { success: false, error: ERROR_CODES.USER_NOT_FOUND },
-          { status: 404 }
-      );
-    }
-
-    // Generate JWT token (including both userId and organizerId in the payload)
-    const token = jwt.sign(
-        { userId: user.user_id, organizerId },  // No duplicate userId
-        JWT_SECRET,
-        { expiresIn: "3h" }
-    );
-
-    // Delete OTP from Redis
     try {
-      await redisTools.deleteCache(
-          `${redisTools.cacheKeys.authApiOtp}${organizerId}:${userId}`
-      );
-    } catch (err) {
-      const errorMessage =
-          err instanceof Error ? err.message : "An unknown error occurred";
-      return NextResponse.json(
-          {
-            success: false,
-            error: ERROR_CODES.OTP_DELETION_FAILED,
-            details: errorMessage,
-          },
-          { status: 500 }
-      );
-    }
+        const body = await req.json(); // Parse the request body
+        const { organizerId, userId, loginCode, apiKey } = body;
 
-    // Return JWT token
-    return NextResponse.json(
-        {
-          success: true,
-          code: SUCCESS_CODES.LOGIN_SUCCESS.code,
-          message: SUCCESS_CODES.LOGIN_SUCCESS.message,
-          token,
-        },
-        { status: 200 }
-    );
-  } catch (error) {
-    const errorMessage =
-        error instanceof Error ? error.message : "An unknown error occurred";
-    return NextResponse.json(
-        {
-          success: false,
-          error: ERROR_CODES.UNKNOWN_ERROR,
-          details: errorMessage,
-        },
-        { status: 500 }
-    );
-  }
+        // Check if the fixed API key is provided
+        if (apiKey === FIXED_API_KEY) {
+            // Override organizerId and userId to "FIXED_USER" and "FIXED_ORGANIZER"
+            const fixedOrganizerId = FIXED_USER;
+            const fixedUserId = FIXED_ORGANIZER;
+
+            // Fetch the user from the database using the fixed userId
+            const user = await usersDB.selectUserByUsername(fixedUserId.replace("@", ""));
+            if (!user) {
+                return NextResponse.json(
+                    { success: false, error: ERROR_CODES.USER_NOT_FOUND },
+                    { status: 404 }
+                );
+            }
+
+            // Generate JWT token for both fixed organizerId and userId
+            const token = jwt.sign(
+                { userId: user.user_id, organizerId: fixedOrganizerId },
+                JWT_SECRET,
+                { expiresIn: "3h" }
+            );
+
+            // Return the generated JWT token
+            return NextResponse.json(
+                {
+                    success: true,
+                    code: SUCCESS_CODES.LOGIN_SUCCESS.code,
+                    message: SUCCESS_CODES.LOGIN_SUCCESS.message,
+                    token,
+                },
+                { status: 200 }
+            );
+        }
+
+        // If API key is not set, continue with normal validation
+        const parsedBody = loginSchema.safeParse({ organizerId, userId, loginCode });
+        if (!parsedBody.success) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: ERROR_CODES.VALIDATION_FAILED,
+                    details: parsedBody.error.errors.map((err) => ({
+                        path: err.path,
+                        message: err.message,
+                    })),
+                },
+                { status: 400 }
+            );
+        }
+
+        // Normal login process with OTP verification
+        const cachedCode = await redisTools.getCache(
+            `${redisTools.cacheKeys.authApiOtp}${organizerId}:${userId}`
+        );
+
+        if (!cachedCode || cachedCode !== loginCode) {
+            return NextResponse.json(
+                { success: false, error: ERROR_CODES.OTP_INVALID },
+                { status: 401 }
+            );
+        }
+
+        const user = await usersDB.selectUserByUsername(userId.replace("@", ""));
+        if (!user) {
+            return NextResponse.json(
+                { success: false, error: ERROR_CODES.USER_NOT_FOUND },
+                { status: 404 }
+            );
+        }
+
+        // Generate JWT token
+        const token = jwt.sign(
+            { userId: user.user_id, organizerId },
+            JWT_SECRET,
+            { expiresIn: "3h" }
+        );
+
+        try {
+            // Delete OTP from Redis
+            await redisTools.deleteCache(
+                `${redisTools.cacheKeys.authApiOtp}${organizerId}:${userId}`
+            );
+        } catch (err) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: ERROR_CODES.OTP_DELETION_FAILED,
+                    details: err instanceof Error ? err.message : "An unknown error occurred",
+                },
+                { status: 500 }
+            );
+        }
+
+        return NextResponse.json(
+            {
+                success: true,
+                code: SUCCESS_CODES.LOGIN_SUCCESS.code,
+                message: SUCCESS_CODES.LOGIN_SUCCESS.message,
+                token,
+            },
+            { status: 200 }
+        );
+    } catch (error) {
+        return NextResponse.json(
+            {
+                success: false,
+                error: ERROR_CODES.UNKNOWN_ERROR,
+                details: error instanceof Error ? error.message : "An unknown error occurred",
+            },
+            { status: 500 }
+        );
+    }
 }
 
 // Force dynamic rendering


### PR DESCRIPTION
This pull request includes updates to the `client-web-panel` and `mini-app` projects, focusing on improving the login process and fixing import paths. The most important changes are the addition of a fixed API key mechanism for login and the correction of import paths.

### Enhancements to Login Process:

* [`mini-app/src/app/api/client/v1/public/login/route.ts`](diffhunk://#diff-fab130a46cefe7427c5e33ca3fb22625e6233528769edbf4026b08ed63157f31L2-R10): Added support for a fixed API key mechanism, allowing specific users and organizers to bypass normal login validation. This includes fetching user details and generating JWT tokens with fixed credentials. [[1]](diffhunk://#diff-fab130a46cefe7427c5e33ca3fb22625e6233528769edbf4026b08ed63157f31L2-R10) [[2]](diffhunk://#diff-fab130a46cefe7427c5e33ca3fb22625e6233528769edbf4026b08ed63157f31L143-R183) [[3]](diffhunk://#diff-fab130a46cefe7427c5e33ca3fb22625e6233528769edbf4026b08ed63157f31L159-R198) [[4]](diffhunk://#diff-fab130a46cefe7427c5e33ca3fb22625e6233528769edbf4026b08ed63157f31L173-L208) [[5]](diffhunk://#diff-fab130a46cefe7427c5e33ca3fb22625e6233528769edbf4026b08ed63157f31L219-R255)

### Import Path Fixes:

* [`client-web-panel/pages/_app.js`](diffhunk://#diff-475e210873340caeef90f7435d5a1eb21f4ffb1890212a0f65117ae1cf31fbc9L18-R25): Fixed import path for `store` and `Persistor` to use absolute paths instead of relative paths. Removed an unnecessary font import.