### PR TITLE
softfix: TonHubSeletor

### DIFF
--- a/mini-app/src/app/_components/molecules/pickers/TonHubpicker.tsx
+++ b/mini-app/src/app/_components/molecules/pickers/TonHubpicker.tsx
@@ -50,12 +50,12 @@ const TonHubPicker: FC<{
           <SelectValue placeholder="Select TON Hub" />
         </SelectTrigger>
         <SelectContent
-          ref={(ref) => {
-            if (!ref) return;
-            ref.ontouchstart = (e) => {
-              e.preventDefault();
-            };
-          }}
+          // ref={(ref) => {
+          //   if (!ref) return;
+          //   ref.ontouchstart = (e) => {
+          //     e.preventDefault();
+          //   };
+          // }}
           className="max-h-[250px]"
         >
           <SelectGroup className="max-h-[250px]">


### PR DESCRIPTION
This pull request includes a small change to the `TonHubPicker` component in the `mini-app/src/app/_components/molecules/pickers/TonHubpicker.tsx` file. The change involves commenting out a block of code that previously set up a touch event to prevent default behavior on the `SelectContent` component.

* [`mini-app/src/app/_components/molecules/pickers/TonHubpicker.tsx`](diffhunk://#diff-2af82396e21174a20e194fb622c8447fe1fc0c42fdc5e9f70e425421dffa5281L53-R58): Commented out the `ref` callback that prevented default touch behavior on the `SelectContent` component.