### PR TITLE
fix: add dealroom refresh to nft claim - add dealroom refresh code as…

### DIFF
--- a/mini-app/src/app/api/v1/dealroom-refresh/route.ts
+++ b/mini-app/src/app/api/v1/dealroom-refresh/route.ts
@@ -1,7 +1,7 @@
 import { getAuthenticatedUser } from "@/server/auth";
-import axios from "axios";
 import { NextRequest } from "next/server";
 import dealRoomService from "@/server/routers/services/DealRoomService";
+import {configProtected} from "@/server/config";
 
 export async function GET(req: NextRequest): Promise<Response> {
   try {
@@ -13,11 +13,9 @@ export async function GET(req: NextRequest): Promise<Response> {
     // Extract code from query or set default
     const url = new URL(req.url);
     const code =
-      url.searchParams.get("code") || "2742f5902ad54152a969f5dac15d716d";
-
+      url.searchParams.get("code") || configProtected?.dealRoomRefreshCode || "";
     // Call the separate fetch function
     const result = await dealRoomService.RefreshGuestList(code);
-
     return Response.json(result);
   } catch (error) {
     console.error("Error fetching URL:", error);

--- a/mini-app/src/app/api/v1/ticket/[nftaddress]/route.ts
+++ b/mini-app/src/app/api/v1/ticket/[nftaddress]/route.ts
@@ -6,6 +6,8 @@ import { type NextRequest } from "next/server";
 import { getAuthenticatedUser } from "@/server/auth";
 import tonCenter from "@/server/routers/services/tonCenter";
 import { decodePayloadToken, verifyToken } from "@/server/utils/jwt";
+import {configProtected} from "@/server/config";
+import dealRoomService from "@/server/routers/services/DealRoomService";
 
 const updateTicketSchema = z.object({
   data: z.object({
@@ -138,6 +140,9 @@ export async function PUT(
       .execute();
     // log user id ticket id and other info
     console.log(`route api ticket nft address : User ${userId} claimed ticket info for NFT ${nft_address}`);
+    // Call the separate fetch function
+    const result = await dealRoomService.RefreshGuestList(configProtected?.dealRoomRefreshCode || "");
+    console.log(`route api ticket nft address : Deal room refresh result ${JSON.stringify(result)}`);
     return Response.json({ message: "user ticket info updated" });
   } catch (error) {
     if (error instanceof SyntaxError)

--- a/mini-app/src/server/routers/tickets.ts
+++ b/mini-app/src/server/routers/tickets.ts
@@ -4,6 +4,7 @@ import ticketDB from "@/server/db/ticket.db";
 import { TRPCError } from "@trpc/server";
 import rewardsService from "@/server/routers/services/rewardsService";
 import dealRoomService from "@/server/routers/services/DealRoomService";
+import {configProtected } from "@/server/config";
 
 // Type guard to check if result is alreadyCheckedIn type
 function isAlreadyCheckedIn(
@@ -40,8 +41,10 @@ export const ticketRouter = router({
     )
     .mutation(async (opts) => {
       const result = await ticketDB.checkInTicket(opts.input.ticketUuid);
+
+
       console.log("result", result);
-      if (!result) {
+      if (!result || result ) {
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to check in the ticket",
@@ -63,7 +66,8 @@ export const ticketRouter = router({
         if (isAlreadyCheckedIn(result)) {
           return { alreadyCheckedIn: true, result: result };
         }
-        const dealRoomResult = await dealRoomService.RefreshGuestList("2742f5902ad54152a969f5dac15d716d");
+
+        const dealRoomResult = await dealRoomService.RefreshGuestList(configProtected?.dealRoomRefreshCode || "");
         return {
           checkInSuccess: true,
           result: result,


### PR DESCRIPTION
This pull request includes several updates to the `mini-app` project, focusing on refactoring code to use the `configProtected` object for configuration values and enhancing the deal room refresh logic.

### Refactoring to use `configProtected`:

* [`mini-app/src/app/api/v1/dealroom-refresh/route.ts`](diffhunk://#diff-7ee6016b458d351dbda674d754d27faeaf88e93ad99b8da501fa12a077001476L16-L20): Replaced hardcoded deal room refresh code with a configurable value from `configProtected`.
* `mini-app/src/app/api/v1/ticket/[nftaddress]/route.ts`: Added `configProtected` import and used its deal room refresh code in the `PUT` method. ([mini-app/src/app/api/v1/ticket/[nftaddress]/route.tsR9-R10](diffhunk://#diff-7a9f46b5958382aae3a5294f0058c3fc83ef440670f7c38b3f350c5f6863fe48R9-R10), [mini-app/src/app/api/v1/ticket/[nftaddress]/route.tsR143-R145](diffhunk://#diff-7a9f46b5958382aae3a5294f0058c3fc83ef440670f7c38b3f350c5f6863fe48R143-R145))
* [`mini-app/src/server/routers/tickets.ts`](diffhunk://#diff-f0f45fd5b7cad55607b2f68fa4e00fc21ec3652d77f07666fbbae1ea46c4bd34R7): Updated the deal room refresh code to use `configProtected` instead of a hardcoded value. [[1]](diffhunk://#diff-f0f45fd5b7cad55607b2f68fa4e00fc21ec3652d77f07666fbbae1ea46c4bd34R7) [[2]](diffhunk://#diff-f0f45fd5b7cad55607b2f68fa4e00fc21ec3652d77f07666fbbae1ea46c4bd34L66-R70)

### Additional Changes:

* [`mini-app/src/server/routers/tickets.ts`](diffhunk://#diff-f0f45fd5b7cad55607b2f68fa4e00fc21ec3652d77f07666fbbae1ea46c4bd34R44-R47): Fixed a logical error in the ticket check-in mutation by removing an unnecessary condition.… setting