### PR TITLE
fix: intit data

### DIFF
--- a/mini-app/src/app/_components/WebAppProvider.tsx
+++ b/mini-app/src/app/_components/WebAppProvider.tsx
@@ -34,7 +34,7 @@ const WebAppProvider = ({ children }: { children: React.ReactNode }) => {
       });
       setIsInitialized(true);
     }
-  }, [webApp, isInitialized, setInitData]);
+  }, [webApp?.initData, isInitialized, setInitData]);
 
   // --------------------------------
   const initialHistoryLength = useRef<number>(0);


### PR DESCRIPTION
This pull request includes a small change to the `mini-app/src/app/_components/WebAppProvider.tsx` file. The change updates the dependency array of a `useEffect` hook to use `webApp?.initData` instead of `webApp`. This ensures that the effect only runs when `initData` changes, rather than any property of `webApp`.

* [`mini-app/src/app/_components/WebAppProvider.tsx`](diffhunk://#diff-e8df4dc62989e789bfcc03cc10bd537291ed152e6879efafa2bb0ad121a4ff9fL37-R37): Updated the dependency array in the `useEffect` hook to use `webApp?.initData` instead of `webApp`.