### PR TITLE
fix: searchfilter hidden for organizer + security bug

### DIFF
--- a/mini-app/src/app/_components/EventCard/EventCard.tsx
+++ b/mini-app/src/app/_components/EventCard/EventCard.tsx
@@ -34,6 +34,7 @@ interface EventCardProps {
     city?: string;
     country?: string;
     participationType?: string;
+    hidden?: number;
   };
   currentUserId?: number;
   children?: React.ReactNode;
@@ -63,6 +64,7 @@ function UnforwardedEventCard(
     city = null,
     country = null,
     participationType = "unknown",
+    hidden = false,
   } = event;
 
   const defaultImage = "/template-images/default.webp";
@@ -76,7 +78,7 @@ function UnforwardedEventCard(
     city || country ? `${city}, ${country}` : location.length > 15 ? `${location.slice(0, 15)}...` : location;
 
   const isOnline = participationType === "online" ? "Online" : participationType === "in_person" ? geoLocation : "unknown";
-
+  const isPublished = !hidden;
   // We open the card or route
   const webApp = useWebApp();
   const router = useRouter();
@@ -135,7 +137,7 @@ function UnforwardedEventCard(
           )}
           <div className='mt-auto text-[#8E8E93]'>
             <Typography variant="subheadline2" className="font-medium mb-1">
-              {isOnline}
+              {isOnline} {isPublished ? "" : " • Not Published"}
             </Typography>
             <div className="flex justify-between">
               <Typography variant='subheadline2' className="font-medium">


### PR DESCRIPTION
This pull request includes several changes to improve the handling of event visibility and user authorization in the `mini-app` project. The changes focus on updating the `EventCard` component and enhancing the backend logic for filtering and querying events.

Changes to `EventCard` component:

* Added a `hidden` property to `EventCardProps` to indicate if an event is hidden. (`mini-app/src/app/_components/EventCard/EventCard.tsx`)
* Updated the `UnforwardedEventCard` function to handle the `hidden` property and display "Not Published" for hidden events. (`mini-app/src/app/_components/EventCard/EventCard.tsx`) [[1]](diffhunk://#diff-703d74cd689c1f205437d47e412a078b48577bbc6e3897d7b5d1dc39bfdcc13fR67) [[2]](diffhunk://#diff-703d74cd689c1f205437d47e412a078b48577bbc6e3897d7b5d1dc39bfdcc13fL79-R81) [[3]](diffhunk://#diff-703d74cd689c1f205437d47e412a078b48577bbc6e3897d7b5d1dc39bfdcc13fL138-R140)

Enhancements to event filtering and user authorization:

* Added the `owner` field to the `getUserEvents` query to include the event owner information. (`mini-app/src/server/db/events.ts`)
* Updated the `getEventsWithFilters` function to accept a `user_id` parameter and apply additional filters based on the user's role and event ownership. (`mini-app/src/server/db/events.ts`) [[1]](diffhunk://#diff-c8f6e8ad4a4bf948c7bc1b3c32c4ba2f8385a24fa8da4a670b6cea2d9849778bL252-R253) [[2]](diffhunk://#diff-c8f6e8ad4a4bf948c7bc1b3c32c4ba2f8385a24fa8da4a670b6cea2d9849778bL274-R279) [[3]](diffhunk://#diff-c8f6e8ad4a4bf948c7bc1b3c32c4ba2f8385a24fa8da4a670b6cea2d9849778bL298-R302) [[4]](diffhunk://#diff-c8f6e8ad4a4bf948c7bc1b3c32c4ba2f8385a24fa8da4a670b6cea2d9849778bL317-R321)
* Modified the `getEventsWithFilters` and `getEventsWithFiltersInfinite` procedures to check user authorization and handle organizer roles appropriately. (`mini-app/src/server/routers/events.ts`) [[1]](diffhunk://#diff-1b1eb03b86b11c81a680fac1a9e68b93eafc93d4ebf694f4d77356d27faa0a3bL670-R713) [[2]](diffhunk://#diff-1b1eb03b86b11c81a680fac1a9e68b93eafc93d4ebf694f4d77356d27faa0a3bR738-R739)