### PR TITLE
fix: avoid alireza to upload smal pictures

### DIFF
--- a/mini-app/src/server/routers/files.ts
+++ b/mini-app/src/server/routers/files.ts
@@ -27,7 +27,12 @@ export const fieldsRouter = router({
               // Remove base64 header and get the image size
               const base64Data = file.replace(/^data:image\/\w+;base64,/, "");
               const image = sizeOf(Buffer.from(base64Data, "base64"));
-
+              if(!image || !image?.width || !image?.height) {
+                throw new TRPCError({
+                  code: "BAD_REQUEST",
+                  message: "Invalid image data",
+                });
+              }
               // Check if the image is square
               if (image.width !== image.height) {
                 throw new TRPCError({
@@ -35,7 +40,12 @@ export const fieldsRouter = router({
                   message: "Only square images are allowed",
                 });
               }
-
+              if (image.width < 400 || image.height < 400) {
+                throw new TRPCError({
+                  code: "BAD_REQUEST",
+                  message: "Image is too small. Minimum size is 400x400.",
+                });
+              }
               // Limit the size of the file (10 MB)
               const MAX_BASE64_SIZE = 10 * 1024 * 1024;
               if (base64Data.length > MAX_BASE64_SIZE) {


### PR DESCRIPTION
This pull request introduces validation checks to the image processing logic in the `fieldsRouter` of the `mini-app` project. The changes ensure that only valid and appropriately sized images are processed.

Validation improvements:

* Added a check to ensure the image data is valid and contains width and height properties. If invalid, a `TRPCError` with a "BAD_REQUEST" code and an "Invalid image data" message is thrown. (`mini-app/src/server/routers/files.ts`)
* Implemented a check to ensure the image dimensions are at least 400x400 pixels. If the image is smaller, a `TRPCError` with a "BAD_REQUEST" code and an "Image is too small. Minimum size is 400x400." message is thrown. (`mini-app/src/server/routers/files.ts`)