### PR TITLE
fix: trim problem

### DIFF
--- a/mini-app/src/app/my/edit/EditForm.tsx
+++ b/mini-app/src/app/my/edit/EditForm.tsx
@@ -54,11 +54,11 @@ export default function EditForm({ data }: { data: Channel }) {
         newErrors.org_channel_name = "Channel name cannot be empty.";
       }
 
-      if (values.org_support_telegram_user_name && !/^@[a-zA-Z0-9_]{5,32}$/.test(values.org_support_telegram_user_name)) {
+      if (values.org_support_telegram_user_name !== "" && !/^@[a-zA-Z0-9_]{5,32}$/.test(values.org_support_telegram_user_name.trim())) {
         newErrors.org_support_telegram_user_name = "Must start with @ and be 5-32 characters long.";
       }
 
-      const xLink = values.org_x_link === xLinkDefault ? "" : values.org_x_link;
+      const xLink = values.org_x_link.trim() === xLinkDefault ? "" : values.org_x_link.trim();
 
       if (xLink && !/^https?:\/\/[a-zA-Z0-9._-]+\.[a-zA-Z]{2,}\/[a-zA-Z0-9_]{1,}$/.test(xLink)) {
         newErrors.org_x_link = "Invalid X handle URL. It should be like https://x.com/ontonlive";

--- a/mini-app/src/server/db/users.ts
+++ b/mini-app/src/server/db/users.ts
@@ -101,15 +101,15 @@ export const updateOrganizerFieldsByUserId = async (
 
     // Only update org_channel_name if it exists in orgData
     if (orgData.org_channel_name !== undefined) {
-      updateData.org_channel_name = xss(orgData.org_channel_name);
+      updateData.org_channel_name = xss(orgData.org_channel_name.trim());
     }
 
     if (orgData.org_support_telegram_user_name !== undefined) {
-      updateData.org_support_telegram_user_name = xss(orgData.org_support_telegram_user_name);
+      updateData.org_support_telegram_user_name = xss(orgData.org_support_telegram_user_name.trim());
     }
 
     if (orgData.org_x_link !== undefined) {
-      updateData.org_x_link = xss(orgData.org_x_link);
+      updateData.org_x_link = xss(orgData.org_x_link.trim());
     }
 
     if (orgData.org_bio !== undefined) {

--- a/mini-app/src/server/routers/organizers.ts
+++ b/mini-app/src/server/routers/organizers.ts
@@ -87,6 +87,7 @@ export const organizerRouter = router({
 
   getPromotedOrganizers: publicProcedure.input(z.object({}).optional()).query(async (): Promise<MinimalOrganizerData[]> => {
     const channelIds: number[] = (config?.promotedChannelIds as unknown as number[]) ?? [];
+    console.log("channelIds", config);
     try {
       const result = await Promise.all(channelIds.map((id) => usersDB.getOrganizerById(id).then(({ data }) => data)));
       return result.filter(Boolean) as MinimalOrganizerData[];


### PR DESCRIPTION
This pull request includes several changes focused on improving data handling and validation in the `mini-app` project. The most important changes involve trimming whitespace from user inputs and adding a debug log statement.

### Data handling and validation improvements:

* [`mini-app/src/app/my/edit/EditForm.tsx`](diffhunk://#diff-96e305f4ab918dca35f4e7b468e064c8413cbc36a610612c68125efa56fc141dL57-R61): Modified validation logic to trim whitespace from `org_support_telegram_user_name` and `org_x_link` before performing regex checks.
* [`mini-app/src/server/db/users.ts`](diffhunk://#diff-c78895ce4d6fbc36b5c0ef93dce21abbd5e2b588979a4a5eec97600d3b5fdb07L104-R112): Updated the `updateOrganizerFieldsByUserId` function to trim whitespace from `org_channel_name`, `org_support_telegram_user_name`, and `org_x_link` before sanitizing inputs.

### Debugging:

* [`mini-app/src/server/routers/organizers.ts`](diffhunk://#diff-d329148eba2e1b68ba4d9b9405e82ae099b2e6ed6c7b1034be1e3efd79e77d0dR90): Added a console log statement to debug the `channelIds` configuration.