### PR TITLE
fix: add gracefull SIGTERM signal in docker compose

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -291,6 +291,8 @@ services:
       restart_policy:
         condition: any
         delay: 3s
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     environment:
       <<: *common-env
       TON_SOCIETY_API_KEY: ${TON_SOCIETY_API_KEY}
@@ -340,6 +342,8 @@ services:
         delay: 10s
         max_attempts: 20
         window: 300s
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     environment:
       <<: *common-env
       MNEMONIC: ${MNEMONIC}
@@ -382,6 +386,8 @@ services:
         delay: 10s
         max_attempts: 20
         window: 40s
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     environment:
       <<: *common-env
       MNEMONIC: ${MNEMONIC}
@@ -426,6 +432,8 @@ services:
       restart_policy:
         condition: on-failure
         delay: 5s
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     environment:
       <<: *common-env
       TON_SOCIETY_API_KEY: ${TON_SOCIETY_API_KEY}
@@ -471,6 +479,8 @@ services:
       restart_policy:
         condition: any
         delay: 20s
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     environment:
       <<: *common-env
       TON_SOCIETY_API_KEY: ${TON_SOCIETY_API_KEY}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,6 +248,8 @@ services:
       args:
         <<: *common-env
     restart: "unless-stopped"
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     environment:
       <<: *common-env
     depends_on:
@@ -268,6 +270,8 @@ services:
       args:
         <<: *common-env
     restart: "unless-stopped"
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     profiles:
       - full
     environment:
@@ -291,6 +295,8 @@ services:
       args:
         <<: *common-env
     restart: "unless-stopped"
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     profiles:
       - full
     environment:
@@ -313,6 +319,8 @@ services:
       args:
         <<: *common-env
     restart: "unless-stopped"
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     profiles:
       - full
     environment:
@@ -339,6 +347,8 @@ services:
       args:
         <<: *common-env
     restart: "unless-stopped"
+    stop_grace_period: 10s
+    stop_signal: SIGTERM
     profiles:
       - full
     environment:


### PR DESCRIPTION
This pull request includes changes to add `stop_grace_period` and `stop_signal` configurations to the `docker-compose.yml` and `docker-compose-server.yml` files. These changes ensure that services have a grace period and a specific signal for stopping, which can help in managing service shutdowns more gracefully.

Changes to `docker-compose-server.yml`:

* Added `stop_grace_period: 10s` and `stop_signal: SIGTERM` to several services to manage service shutdowns more gracefully. [[1]](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4R294-R295) [[2]](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4R345-R346) [[3]](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4R389-R390) [[4]](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4R435-R436) [[5]](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4R482-R483)

Changes to `docker-compose.yml`:

* Added `stop_grace_period: 10s` and `stop_signal: SIGTERM` to multiple services to ensure a consistent shutdown process. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R251-R252) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R273-R274) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R298-R299) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R322-R323) [[5]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R350-R351)