### PR TITLE
fix: add moderation bot service verifier

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -9,7 +9,7 @@ on:
       - "devops"
       - "main"
     paths:
-#      - 'client-web-panel/**'
+      #      - 'client-web-panel/**'
       - 'devops/**'
       - 'docker-compose-server.yml'
       - 'mini-app/**'
@@ -143,7 +143,7 @@ jobs:
           REGISTRY_URL: ${{ secrets.REGISTRY_URL }}
           REGISTRY_USER_NAME: ${{ secrets.REGISTRY_USER_NAME }}
         run: echo "${REGISTRY_USER_PASSWORD}" | docker login ${REGISTRY_URL} -u ${REGISTRY_USER_NAME} --password-stdin
-            
+
 
 
       - name: Build and push image for ${{ matrix.service }}
@@ -313,12 +313,12 @@ jobs:
             🧑 ‍💻Actor: ${{ github.actor }}
             ❌❌Build failed❌❌
             🔍 See Changes: https://github.com/${{ github.repository }}/commit/${{ github.sha }}"
-
+  
   
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [determine-services,build-and-push ]
+    needs: [ determine-services,build-and-push ]
     if: ${{ needs.determine-services.outputs.services_to_build != '[]' && github.event_name == 'push' }}
     permissions:
       contents: write
@@ -329,20 +329,20 @@ jobs:
       ALLMYSECRETS: ${{ toJSON(secrets) }}
       ALLMYVARS: ${{ toJSON(vars) }}
     steps:
-#      - name: Manual Approval
-#        if: |
-#          github.ref_name == 'main' ||
-#          github.ref_name == 'staging'
-#        uses: trstringer/manual-approval@v1
-#        with:
-#          secret: ${{ github.token }}
-#          approvers: ${{ github.actor }}
-#          minimum-approvals: 1
-#          issue-title: "Deploying to ${{ github.ref_name }} branch"
-#          issue-body: "Please approve or deny the deployment to ${{ github.ref_name }} branch"
-#          exclude-workflow-initiator-as-approver: false
-#          additional-approved-words: 'approve,approved,lgtm,yes'
-#          additional-denied-words: 'deny,denied,no'
+      #      - name: Manual Approval
+      #        if: |
+      #          github.ref_name == 'main' ||
+      #          github.ref_name == 'staging'
+      #        uses: trstringer/manual-approval@v1
+      #        with:
+      #          secret: ${{ github.token }}
+      #          approvers: ${{ github.actor }}
+      #          minimum-approvals: 1
+      #          issue-title: "Deploying to ${{ github.ref_name }} branch"
+      #          issue-body: "Please approve or deny the deployment to ${{ github.ref_name }} branch"
+      #          exclude-workflow-initiator-as-approver: false
+      #          additional-approved-words: 'approve,approved,lgtm,yes'
+      #          additional-denied-words: 'deny,denied,no'
       - name: Authenticate to GitHub Container Registry
         env:
           CR_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -394,7 +394,7 @@ jobs:
           echo "CR_PAT=\"${CR_PAT}\"" >> $env_file
           
           echo "Environment variables script generated successfully."
- 
+
 
       - name: Set up SSH Environment Variables
         id: set-env-vars
@@ -485,7 +485,7 @@ jobs:
             if [ -z "$CR_PAT" ]; then
               echo "CR_PAT is not set or is empty"; exit 1;
             fi
-             
+          
             echo "services to build: $services_to_build"
             # Remove the square brackets and split by comma
             echo "Pulling latest images of changed services..."
@@ -510,7 +510,7 @@ jobs:
                   rm -f /home/tonont/caddy/tmp/$branch_name/Caddyfile
                   mkdir -p /home/tonont/caddy/tmp/$branch_name/
                   mkdir -p /home/tonont/caddy/Caddyfile
-                  
+          
                   export CADDYFILE_PATH="/home/tonont/caddy/tmp/$branch_name.caddyfile"
                   sh devops/generate-caddyfile-by-address.sh
                   mv /home/tonont/caddy/tmp/$branch_name.caddyfile /home/tonont/caddy/$branch_name.caddyfile
@@ -564,15 +564,18 @@ jobs:
                 echo "Special handling for mini-app service"
                 echo "Updating $branch_name_mini-app"
                 docker service update --update-failure-action rollback --update-max-failure-ratio 0.2 --force $branch_name\_\mini-app
-                
+          
                 echo "Updating $branch_name_mini-app-notification-socket"
                 docker service update --update-failure-action rollback --update-max-failure-ratio 0.2 --force $branch_name\_\mini-app-notification-socket
-                
+          
                 echo "Updating $branch_name_mini-app-poa-worker"
                 docker service update --update-failure-action rollback --update-max-failure-ratio 0.2 --force $branch_name\_\mini-app-poa-worker
-                
+          
                 echo "Updating $branch_name_mini-app-sbt-worker"
                 docker service update --update-failure-action rollback --update-max-failure-ratio 0.2 --force $branch_name\_\mini-app-sbt-worker
+          
+                echo "Updating $branch_name_mini-app-moderation-bot"
+                docker service update --update-failure-action rollback --update-max-failure-ratio 0.2 --force $branch_name\_\mini-app-moderation-bot
               else
                 echo "docker service update --force $branch_name\_\$service"
                 docker service update --update-failure-action rollback --update-max-failure-ratio 0.2  --force $branch_name\_\$service
@@ -631,6 +634,6 @@ jobs:
             🧑 ‍💻Actor: ${{ github.actor }}
           
             📝 branch: ${{ github.ref }}
-            
+          
             ❌ ❌ deployment failed ❌ ❌ 
             "

--- a/mini-app/deploy.test
+++ b/mini-app/deploy.test
@@ -12,3 +12,4 @@ after masoud build
 after something
 clear registery
 dep stage
+deploy verify test


### PR DESCRIPTION
This pull request includes updates to the deployment process for mini-app services and adds a new deployment verification step in the test deployment script.

Deployment process updates:

* [`.github/workflows/build-push-deploy.yml`](diffhunk://#diff-d28063c33074add94dc5919b650df438680ad1e1d7aebdc898f8a47b6405ec51R576-R578): Added a new step to update the `mini-app-moderation-bot` service with specific parameters for failure action and maximum failure ratio.

Test deployment script updates:

* [`mini-app/deploy.test`](diffhunk://#diff-a510f40692af60bfc181ef7ee089e41ff7eaeab197d5d12b3fdbc027d3e4b82aR15): Added a `deploy verify test` step after the deployment stage to ensure the deployment is verified.