### PR TITLE
fix: add rate limiting for online without registeration event passwor…

### DIFF
--- a/mini-app/src/constants.ts
+++ b/mini-app/src/constants.ts
@@ -1,5 +1,3 @@
-
-
 export const gmtTimeZones = [
   "GMT",
   "GMT+1",
@@ -608,84 +606,84 @@ export const isDevStage = process.env.ENV === "development" || process.env.NODE_
 export const PLACEHOLDER_IMAGE = "https://storage.onton.live/ontonimage/test_image.png";
 export const PLACEHOLDER_VIDEO = "https://storage.onton.live/ontonvideo/event/dCsiY_1731355946593_event_video.mp4";
 
-export const UPLOAD_IMAGE_RATE_LIMIT = { window: 60 , max: 2 };
-export const UPLOAD_VIDEO_RATE_LIMIT = { window: 60 , max: 5 };
-
-export const NonVerifiedHubsIds= ["12", "33"]
+export const UPLOAD_IMAGE_RATE_LIMIT = { window: 60, max: 2 };
+export const UPLOAD_VIDEO_RATE_LIMIT = { window: 60, max: 5 };
+export const EVENT_PASSWORD_RATE_LIMIT = { window: 60, max: 3 };
+export const NonVerifiedHubsIds = ["12", "33"];
 export const hardCodedHubs = [
-    {
-      id: "1",
-      name: "Global",
-    },
-    {
-      id: "2",
-      name: "Europe",
-    },
-    {
-      id: "3",
-      name: "India",
-    },
-    {
-      id: "4",
-      name: "Korea",
-    },
-    {
-      id: "5",
-      name: "SEA",
-    },
-    {
-      id: "6",
-      name: "Caucasus",
-    },
-    {
-      id: "7",
-      name: "Turkiye",
-    },
-    {
-      id: "8",
-      name: "CIS",
-    },
-    {
-      id: "9",
-      name: "UAE",
-    },
-    {
-      id: "10",
-      name: "UK",
-    },
-    {
-      id: "11",
-      name: "Hong Kong",
-    },
-    {
-      id: "12",
-      name: "TON Square",
-    },
-    {
-      id: "13",
-      name: "Community",
-    },
-    {
-      id: "33",
-      name: "Onton",
-    },
-    {
-      id: "34",
-      name: "Japan",
-    },
-    {
-      id: "49",
-      name: "Balkans",
-    },
-  ];
+  {
+    id: "1",
+    name: "Global",
+  },
+  {
+    id: "2",
+    name: "Europe",
+  },
+  {
+    id: "3",
+    name: "India",
+  },
+  {
+    id: "4",
+    name: "Korea",
+  },
+  {
+    id: "5",
+    name: "SEA",
+  },
+  {
+    id: "6",
+    name: "Caucasus",
+  },
+  {
+    id: "7",
+    name: "Turkiye",
+  },
+  {
+    id: "8",
+    name: "CIS",
+  },
+  {
+    id: "9",
+    name: "UAE",
+  },
+  {
+    id: "10",
+    name: "UK",
+  },
+  {
+    id: "11",
+    name: "Hong Kong",
+  },
+  {
+    id: "12",
+    name: "TON Square",
+  },
+  {
+    id: "13",
+    name: "Community",
+  },
+  {
+    id: "33",
+    name: "Onton",
+  },
+  {
+    id: "34",
+    name: "Japan",
+  },
+  {
+    id: "49",
+    name: "Balkans",
+  },
+];
 
 export const nonVerifiedHubs = [
-    {
-      id: "12",
-      name: "TON Square",
-    },
-    {
-      id: "33",
-      name: "Onton",
-    },
-  ];
+  {
+    id: "12",
+    name: "TON Square",
+  },
+  {
+    id: "33",
+    name: "Onton",
+  },
+];


### PR DESCRIPTION
This pull request includes several changes to the `mini-app` project, focusing on rate limiting and error handling improvements. The most important changes include adding a rate limit for event password attempts, updating error messages, and ensuring proper handling of events with registration.

Rate limiting and error handling improvements:

* [`mini-app/src/constants.ts`](diffhunk://#diff-65fcbdb0fd32e2c160f0801c496db1047c9fd5ec6b47ebe31222820d1a902ed4L613-R612): Added `EVENT_PASSWORD_RATE_LIMIT` constant to define the rate limit for event password attempts.
* [`mini-app/src/server/routers/userEventFields.ts`](diffhunk://#diff-834f2e1e9257feeb62a05eec59f088fb7f95fd786d146cb94905b804f34c23f7R9-R10): Imported `checkRateLimit` and `EVENT_PASSWORD_RATE_LIMIT` to enforce rate limiting on event password attempts.
* [`mini-app/src/server/routers/userEventFields.ts`](diffhunk://#diff-834f2e1e9257feeb62a05eec59f088fb7f95fd786d146cb94905b804f34c23f7R23-R34): Added logic to check the rate limit before allowing a user to attempt an event password. Throws a `TOO_MANY_REQUESTS` error if the limit is exceeded.
* [`mini-app/src/server/routers/userEventFields.ts`](diffhunk://#diff-834f2e1e9257feeb62a05eec59f088fb7f95fd786d146cb94905b804f34c23f7L68-R88): Updated error message to include the number of remaining attempts when an incorrect password is entered.
* [`mini-app/src/server/routers/userEventFields.ts`](diffhunk://#diff-834f2e1e9257feeb62a05eec59f088fb7f95fd786d146cb94905b804f34c23f7R44-R49): Added a check to prevent the use of passwords for events with registration, throwing a `BAD_REQUEST` error if attempted.