### PR TITLE
fix: add event data redis caching for ptma

### DIFF
--- a/mini-app/src/app/api/v1/event/[id]/route.ts
+++ b/mini-app/src/app/api/v1/event/[id]/route.ts
@@ -11,6 +11,7 @@ import { decodePayloadToken, verifyToken } from "@/server/utils/jwt";
 import { OrderRow } from "@/db/schema/orders";
 import { getByEventUuidAndUserId } from "@/server/db/eventRegistrants.db";
 import "@/lib/gracefullyShutdown";
+import eventDB, { fetchEventById } from "@/server/db/events";
 
 // Helper function for retrying the HTTP request
 async function getRequestWithRetry(uri: string, retries: number = 3): Promise<any> {
@@ -107,11 +108,12 @@ export async function GET(req: NextRequest, { params }: { params: { id: string }
     const searchParams = req.nextUrl.searchParams;
     const dataOnly = searchParams.get("data_only") as "true" | undefined;
 
-    const unsafeEvent = await db.query.events.findFirst({
-      where(fields, { eq }) {
-        return eq(fields.event_uuid, event_uuid);
-      },
-    });
+    // const unsafeEvent = await db.query.events.findFirst({
+    //   where(fields, { eq }) {
+    //     return eq(fields.event_uuid, event_uuid);
+    //   },
+    // });
+    const unsafeEvent = await eventDB.fetchEventByUuid(event_uuid);
 
     if (!unsafeEvent?.event_uuid) {
       return Response.json({ error: "Event not found" }, { status: 400 });


### PR DESCRIPTION
This pull request includes changes to the `mini-app/src/app/api/v1/event/[id]/route.ts` file to improve the way events are fetched from the database. The most important changes include importing the `eventDB` module and replacing the existing database query with a call to `fetchEventByUuid`.

Database fetching improvements:

* `mini-app/src/app/api/v1/event/[id]/route.ts`: Added import for `eventDB` and `fetchEventById` from `@/server/db/events`. ([mini-app/src/app/api/v1/event/[id]/route.tsR14](diffhunk://#diff-5cb1bf1b6776e14fc6c684960c1246b59209dabbed650c1f614ca2dc3f971443R14))
* `mini-app/src/app/api/v1/event/[id]/route.ts`: Replaced the existing database query with a call to `eventDB.fetchEventByUuid` to fetch events by UUID. ([mini-app/src/app/api/v1/event/[id]/route.tsL110-R116](diffhunk://#diff-5cb1bf1b6776e14fc6c684960c1246b59209dabbed650c1f614ca2dc3f971443L110-R116))