### PR TITLE
fix: increase postgres memory + increase connection instances + add m…

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -139,7 +139,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 8000M
+          memory: 16000M
           cpus: "5.0"
       mode: global
       update_config:

--- a/mini-app/src/db/db.ts
+++ b/mini-app/src/db/db.ts
@@ -7,7 +7,7 @@ const isProduction = process.env.NODE_ENV === "production";
 
 // PostgresSQL Connection Pool Configuration
 export const queryClient = postgres(process.env.DATABASE_URL!, {
-  max: 20, // in production, we run 24 instances, so we can have 18 connections  (24 * 18 = 432)
+  max: 30, // in production, we run 12 instances, so we can have 30 connections per instance (360 connections)
   idle_timeout: 5, // Close idle connections after 5 seconds of inactivity
   connect_timeout: 10, // Fail connection attempts after 10 seconds
   ssl: process.env.DATABASE_SSL === "true" ? "require" : false, // Enable SSL if needed

--- a/mini-app/src/sockets/notificationWorker.ts
+++ b/mini-app/src/sockets/notificationWorker.ts
@@ -66,7 +66,7 @@ const consumeMessages = async (rabbit: RabbitMQ, io: Server, queue: QueueNamesTy
         // Emit the notification or requeue it if the user is not online
         await emitNotification(io, userId, message, channel, msg);
       } catch (error) {
-        logger.error("Error processing RabbitMQ message:", error);
+        logger.error("Error processing RabbitMQ message:", error, msg);
         channel.nack(msg, false, true); // Requeue the message
       }
 


### PR DESCRIPTION
This pull request includes several changes to resource allocation, database connection configuration, and error logging. The most important changes are listed below:

Resource Allocation:
* [`docker-compose-server.yml`](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4L142-R142): Increased the memory limit for the service from 8000M to 16000M.

Database Configuration:
* [`mini-app/src/db/db.ts`](diffhunk://#diff-8be809cbae4889df54291c54e7149751c03419c5be0c23e4e7685eeff519d850L10-R10): Increased the maximum number of connections in the PostgreSQL connection pool from 20 to 30, adjusting for the number of instances in production.

Error Logging:
* [`mini-app/src/sockets/notificationWorker.ts`](diffhunk://#diff-da17a26243014852725590416501b5c9dcd2df3c433ac86aee2afd43bbed7b27L69-R69): Enhanced error logging for RabbitMQ message processing by including the message content in the log.