### PR TITLE
fix: check block bot cron will waite until the end - it will check th…

### DIFF
--- a/mini-app/src/server/db/users.ts
+++ b/mini-app/src/server/db/users.ts
@@ -598,12 +598,30 @@ export const updateUserRole = async (
  * Offset-based fetch: returns up to `limit` users after skipping `offset` rows.
  */
 export const fetchUsersByOffset = async (offset: number, limit: number) => {
+  // We'll select user_id from "users"
+  // Only rows where updated_at < NOW() - INTERVAL '10 days'
+  // Order results by updated_at ascending
+  // Offset/limit for pagination
   const query = db
     .select({
       user_id: users.user_id,
     })
     .from(users)
-    .orderBy(users.user_id)
+    .where(
+      sql`
+        ${users.updatedAt} IS NULL 
+        OR
+        ${users.updatedAt}
+        <
+        NOW
+        (
+        )
+        -
+        interval
+        '10 days'
+    `
+    )
+    .orderBy(users.updatedAt) // ascending by default
     .offset(offset)
     .limit(limit);
 

--- a/mini-app/src/workers/cronJobScheduler.ts
+++ b/mini-app/src/workers/cronJobScheduler.ts
@@ -36,8 +36,19 @@ async function MainCronJob() {
   new CronJob("*/11 * * * * *", cronJobRunner(cronJobs.TsCsbtTicketOrder), null, true);
   new CronJob("*/21 * * * * *", cronJobs.OrganizerPromoteProcessing, null, true);
   new CronJob("0 */30 * * * *", cronJobs.syncSbtCollectionsForEvents, null, true);
-  // run every Tuesday at 1:00 AM
-  new CronJob("0 1 * * 2", cronJobs.CheckAllUsersBlock, null, true);
+  new CronJob(
+    "0 1 * * *", // (cronTime) => at 1:00 AM
+    cronJobs.CheckAllUsersBlock, // (onTick)   => function to run
+    null, // (onComplete) => no special callback after job
+    true, // (start) => start immediately
+    null, // (timeZone) => e.g. "UTC" or your local
+    null, // (context)
+    false, // (runOnInit) => don't run immediately on app start
+    null, // (utcOffset)
+    false, // (unrefTimeout)
+    true // (waitForCompletion) => wait for onTick to finish
+    // No errorHandler passed
+  );
 }
 
 MainCronJob().then(() => logger.log("Cron Jobs Started"));


### PR DESCRIPTION
This pull request includes several changes to improve the codebase and enhance functionality. The most significant changes include updating the `fetchUsersByOffset` query, modifying the `MainCronJob` function, and refactoring various functions in `telegram-bot/src/db/db.ts` to use arrow functions.

### Improvements to database queries:

* [`mini-app/src/server/db/users.ts`](diffhunk://#diff-c78895ce4d6fbc36b5c0ef93dce21abbd5e2b588979a4a5eec97600d3b5fdb07R601-R624): Updated the `fetchUsersByOffset` query to select users where `updated_at` is null or older than 10 days, and order results by `updated_at`.

### Enhancements to cron job scheduling:

* [`mini-app/src/workers/cronJobScheduler.ts`](diffhunk://#diff-6606cd122da53f48e79c1b5135f09161f6afb9e6bb40c177d3f40eced56e7dfcL39-R51): Modified the `MainCronJob` function to include detailed parameters for the `CheckAllUsersBlock` cron job, improving readability and configurability.

### Refactoring to use arrow functions:

* [`telegram-bot/src/db/db.ts`](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL18-R18): Refactored multiple functions to use arrow function syntax, improving consistency and modernizing the codebase. Functions updated include `createDatabase`, `getEvent`, `countReferrals`, `addVisitor`, `changeRole`, `getUser`, `isUserAdmin`, `getEventTickets`, `fetchOntonSetting`, `getAdminOrganizerUsers`, `updateUserProfile`, `processCsvLinesForSbtDist`, and `getApprovedRegistrants`. [[1]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL18-R18) [[2]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL48-R50) [[3]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL81-R85) [[4]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL111-R113) [[5]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL136-R138) [[6]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL195-R197) [[7]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL209-R220) [[8]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL245-R247) [[9]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL276-R278) [[10]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL291-R293) [[11]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL306-R306) [[12]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL331-R341) [[13]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL347-R352) [[14]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL365-R372) [[15]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL489-R496) [[16]](diffhunk://#diff-8e654e54e343f1f565b1bea12d180539bce3b11f8ac73b2d2859009d2049456eL509-R513)