### PR TITLE
fix: migration create types

### DIFF
--- a/mini-app/drizzle/0011_flashy_boomerang.sql
+++ b/mini-app/drizzle/0011_flashy_boomerang.sql
@@ -1,22 +1,45 @@
-CREATE TABLE IF NOT EXISTS "users_score" (
-	"id" bigserial PRIMARY KEY NOT NULL,
-	"user_id" bigint NOT NULL,
-	"activity_type" "users_score_activity_type",
-	"point" smallint,
-	"active" boolean,
-	"item_id" bigint,
-	"item_type" "user_score_item_type",
-	"created_at" timestamp (6)
+CREATE TYPE "public"."user_score_item_type" AS ENUM (
+    'event',
+    'task'
+    );
+CREATE TYPE "public"."users_score_activity_type" AS ENUM (
+    'free_online_event',
+    'free_offline_event',
+    'paid_online_event',
+    'paid_offline_event',
+    'join_onton'
+    );
+CREATE TYPE ton_society_status_enum AS ENUM (
+    'NOT_CLAIMED',
+    'CLAIMED',
+    'NOT_ELIGIBLE',
+    'RECEIVED'
+    );
+CREATE TABLE IF NOT EXISTS "users_score"
+(
+    "id"            bigserial PRIMARY KEY NOT NULL,
+    "user_id"       bigint                NOT NULL,
+    "activity_type" "users_score_activity_type",
+    "point"         smallint,
+    "active"        boolean,
+    "item_id"       bigint,
+    "item_type"     "user_score_item_type",
+    "created_at"    timestamp(6)
 );
 --> statement-breakpoint
-ALTER TABLE "rewards" ADD COLUMN "ton_society_status" "ton_society_status_enum" DEFAULT 'NOT_CLAIMED' NOT NULL;--> statement-breakpoint
-DO $$ BEGIN
- ALTER TABLE "users_score" ADD CONSTRAINT "users_score_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE no action ON UPDATE no action;
-EXCEPTION
- WHEN duplicate_object THEN null;
-END $$;
+ALTER TABLE "rewards"
+    ADD COLUMN "ton_society_status" "ton_society_status_enum" DEFAULT 'NOT_CLAIMED' NOT NULL;--> statement-breakpoint
+DO
+$$
+    BEGIN
+        ALTER TABLE "users_score"
+            ADD CONSTRAINT "users_score_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users" ("user_id") ON DELETE no action ON UPDATE no action;
+    EXCEPTION
+        WHEN duplicate_object THEN null;
+    END
+$$;
 --> statement-breakpoint
-CREATE UNIQUE INDEX IF NOT EXISTS "users_score_user_id_activity_type_active_item_id_item_type_key" ON "users_score" USING btree ("user_id","activity_type","active","item_id","item_type");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "users_score_user_id_activity_type_active_item_id_item_type_key" ON "users_score" USING btree ("user_id", "activity_type", "active", "item_id", "item_type");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "users_score_activity_type_idx" ON "users_score" USING btree ("activity_type");--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "users_score_item_id_item_type_idx" ON "users_score" USING btree ("item_id","item_type");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "users_score_item_id_item_type_idx" ON "users_score" USING btree ("item_id", "item_type");--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "users_score_user_id_idx" ON "users_score" USING btree ("user_id");


### PR DESCRIPTION
This pull request includes several changes to the `mini-app/drizzle/0011_flashy_boomerang.sql` file, focusing on the creation of new types and modifications to the `users_score` table. The most important changes include the addition of new ENUM types, the restructuring of the `users_score` table, and updates to the `rewards` table.

Schema updates:

* Added new ENUM types: `user_score_item_type`, `users_score_activity_type`, and `ton_society_status_enum`.
* Modified the `users_score` table to use the new ENUM types and added a foreign key constraint for `user_id`. [[1]](diffhunk://#diff-e379fff707da5740ce30f67955eb1857f6c850ebbbb7386bb3dc72cd3d283e4aL1-R19) [[2]](diffhunk://#diff-e379fff707da5740ce30f67955eb1857f6c850ebbbb7386bb3dc72cd3d283e4aL12-R40)

Table modifications:

* Updated the `rewards` table to include a new column `ton_society_status` with the ENUM type `ton_society_status_enum`.