### PR TITLE
fix: rabbit mq typing build error

### DIFF
--- a/mini-app/package.json
+++ b/mini-app/package.json
@@ -141,7 +141,7 @@
     "@redux-devtools/extension": "^3.3.0",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
-    "@types/amqplib": "^0.10.5",
+    "@types/amqplib": "^0.10.7",
     "@types/bcrypt": "^5.0.2",
     "@types/better-sqlite3": "^7.6.8",
     "@types/clamav.js": "^0.12.4",


### PR DESCRIPTION
This pull request includes various updates and refactoring changes to the `mini-app` project, particularly focusing on the `rabbitMQ.ts` file and the `package.json` file. The key changes involve updating dependencies, modifying imports, and refactoring the `RabbitMQ` class for better type usage and code consistency.

Dependency updates:

* Updated `@types/amqplib` from version `0.10.5` to `0.10.7` in `mini-app/package.json`.

Refactoring and code improvements in `rabbitMQ.ts`:

* Split the import statement for `amqplib` to separate the default import and named imports, and added `ChannelModel` to the named imports.
* Changed the type of the `connection` property from `Connection` to `ChannelModel` in the `RabbitMQ` class.
* Updated the return type of the `connect` method to `ChannelModel`.
* Removed redundant default parameter values in methods `push`, `consume`, and `bindQueue` [[1]](diffhunk://#diff-98213f62f7f898499bc61ea012d7704dc961b8483fad6d34be7cfe71fa5c7610L143-R144) [[2]](diffhunk://#diff-98213f62f7f898499bc61ea012d7704dc961b8483fad6d34be7cfe71fa5c7610L170-R171) [[3]](diffhunk://#diff-98213f62f7f898499bc61ea012d7704dc961b8483fad6d34be7cfe71fa5c7610L191-R192) [[4]](diffhunk://#diff-98213f62f7f898499bc61ea012d7704dc961b8483fad6d34be7cfe71fa5c7610L265-R266).
* Refactored the `pushToQueue` and `consumeFromQueue` utility functions to use single-line parameter lists.