### PR TITLE
add: photo and video message to broadcast message

### DIFF
--- a/telegram-bot/src/types/MyContext.ts
+++ b/telegram-bot/src/types/MyContext.ts
@@ -88,11 +88,16 @@ export interface SessionData {
   /* ------------------ Play2Win Featured Flow ------------------ */
   play2winStep?: "askList" | "done";
   /* ------------------ Broadcast Flow ------------------ */
-  broadcastStep?: "chooseType" | "askEvent" | "askCsv" | "askMessage" | "done";
+  broadcastStep?: "chooseTarget" | "askEventUuid" | "askCsv" | "askBroadcast" | "done";
   broadcastType?: "event" | "csv";
-  broadcastEventUUID?: string;       // store the event ID if chosen
-  broadcastCsvUserIds?: string[];    // store user IDs from CSV
-  broadcastMessage?: string;
+
+  // For Event-based broadcast
+  broadcastEventUuid?: string;
+  broadcastEventTitle?: string;
+  broadcastUserIds?: string[];  // consolidated list of user IDs to broadcast to
+
+  // For CSV-based broadcast
+  broadcastCsvUserIds?: string[];
   /* ------------------ SBT Collection Flow ------------------ */
   collectionStep?:
     | "CHOOSE_HUB"


### PR DESCRIPTION
This pull request includes significant improvements and refactoring to the `broadcastComposer` in the Telegram bot, focusing on enhancing the broadcast flow and handling logic. The main changes involve renaming steps for clarity, adding detailed comments, and consolidating user ID handling for both event and CSV-based broadcasts.

### Improvements to broadcast flow:

* [`telegram-bot/src/composers/broadcast.ts`](diffhunk://#diff-89473cd2d20f1866a8a87d959dda0e55bcc9c0a85d77b3003d403a9351a62fefL4-R54): Renamed broadcast steps for better clarity and added detailed comments. The steps now include `chooseTarget`, `askEventUuid`, `askCsv`, and `askBroadcast`.
* [`telegram-bot/src/types/MyContext.ts`](diffhunk://#diff-bf4d6429d89407efd2f21851f7be0b4f43519743d4be7d3344312be0ea9c9a6bL91-R100): Updated the `SessionData` interface to reflect the new step names and added new session variables for event titles and user IDs.

### Enhanced user ID handling:

* [`telegram-bot/src/composers/broadcast.ts`](diffhunk://#diff-89473cd2d20f1866a8a87d959dda0e55bcc9c0a85d77b3003d403a9351a62fefL4-R54): Consolidated user ID handling by storing user IDs in a single session variable `broadcastUserIds`, regardless of whether they come from an event or a CSV file.

### Additional improvements:

* [`telegram-bot/src/composers/broadcast.ts`](diffhunk://#diff-89473cd2d20f1866a8a87d959dda0e55bcc9c0a85d77b3003d403a9351a62fefL4-R54): Added a small delay between sending messages to reduce the risk of hitting rate limits.
* [`telegram-bot/src/composers/broadcast.ts`](diffhunk://#diff-89473cd2d20f1866a8a87d959dda0e55bcc9c0a85d77b3003d403a9351a62fefL4-R54): Added detailed error handling and logging for failed message broadcasts.