### PR TITLE
Staging

### DIFF
--- a/telegram-bot/src/constants.ts
+++ b/telegram-bot/src/constants.ts
@@ -22,3 +22,15 @@ export const additionalRecipients = [
   91896720, //elbabix
   548648769, // Radiophp
 ];
+
+/**
+ * Regex to detect invite placeholders: {invite:-100XXXX}
+ * capturing -?\d+ as group #1
+ */
+export const INVITE_PLACEHOLDER_REGEX = /\{invite:(-?\d+)\}/g;
+
+/** Existing affiliate placeholders: {onion1-campaign}, etc. */
+export const AFFILIATE_PLACEHOLDERS = [
+  "{onion1-special-affiliations}",
+  "{onion1-campaign}",
+];

--- a/telegram-bot/src/cronJobs/pollSenderCron.ts
+++ b/telegram-bot/src/cronJobs/pollSenderCron.ts
@@ -18,11 +18,11 @@ import {
  *                  else increment retry or final fail after 10 tries
  */
 export async function pollSenderCron(bot: Bot) {
-    logger.info("pollSenderCron: started");
+
 
     const rows = await fetchPendingPollSends(50);
     if (!rows.length) {
-        logger.info("pollSenderCron: no rows to process. Exiting.");
+        //logger.info("pollSenderCron: no rows to process. Exiting.");
         return;
     }
 

--- a/telegram-bot/src/db/affiliateLinks.ts
+++ b/telegram-bot/src/db/affiliateLinks.ts
@@ -123,3 +123,76 @@ export async function getAffiliateLinksByItemId(itemId: number | string) {
     client.release();
   }
 }
+
+/* -------------------------------------------------------------------------- */
+/* getOrCreateSingleAffiliateLink => for affiliate placeholders              */
+/* -------------------------------------------------------------------------- */
+export async function getOrCreateSingleAffiliateLink(
+    userId: number,
+    itemType: string,
+    baseTitle: string,
+    groupTitle: string,
+) {
+  const client = await pool.connect();
+  try {
+    const sqlCheck = `
+      SELECT id, link_hash, title, group_title
+      FROM affiliate_links
+      WHERE "item_type" = $1
+        AND "Item_id" = 0
+        AND "affiliator_user_id" = $2
+      LIMIT 1
+    `;
+    const resCheck = await client.query(sqlCheck, [itemType, userId]);
+    if (resCheck.rowCount > 0) {
+      // If found => update groupTitle if needed
+      const existingLink = resCheck.rows[0];
+      if (existingLink.group_title !== groupTitle) {
+        await client.query(
+            `UPDATE affiliate_links
+             SET "group_title"=$1
+             WHERE "id"=$2`,
+            [groupTitle, existingLink.id],
+        );
+      }
+      return {
+        id: existingLink.id,
+        link_hash: existingLink.link_hash,
+        title: existingLink.title,
+        group_title: groupTitle,
+      };
+    }
+  } finally {
+    client.release();
+  }
+
+  // Not found => create new
+  const creation = await createAffiliateLinks({
+    eventId: 0,
+    userId,
+    itemType,
+    baseTitle,
+    count: 1,
+  });
+  const newLink = creation.links[0];
+
+  // Update group_title
+  const client2 = await pool.connect();
+  try {
+    await client2.query(
+        `UPDATE affiliate_links
+         SET "group_title"=$1
+         WHERE "id"=$2`,
+        [groupTitle, newLink.id],
+    );
+  } finally {
+    client2.release();
+  }
+
+  return {
+    id: newLink.id,
+    link_hash: newLink.link_hash,
+    title: newLink.title,
+    group_title: groupTitle,
+  };
+}

--- a/telegram-bot/src/db/db.ts
+++ b/telegram-bot/src/db/db.ts
@@ -31,6 +31,15 @@ export { addTelegramBotVisitor } from "./visitors";
 // Re-export onton settings
 export { upsertPlay2winFeatured, getPlay2winFeatured, fetchOntonSetting, setBanner } from "./ontonSettings";
 
+// Re-export polls
+export {
+  getPollRow,
+  markPollSentFailed,
+  markPollSentSuccess,
+} from "./polls";
+// Re-export invite links
+export { getOrCreateSingleInviteLinkForUserAndChat } from "./inviteLink";
+
 // Re-export event registrants
 export { getEventTickets, getApprovedRegistrants } from "./eventRegistrants";
 

--- a/telegram-bot/src/db/inviteLink.ts
+++ b/telegram-bot/src/db/inviteLink.ts
@@ -1,0 +1,59 @@
+/* -------------------------------------------------------------------------- */
+/* getOrCreateSingleInviteLinkForUserAndChat => DB approach to re-use invites*/
+/* -------------------------------------------------------------------------- */
+import {MyContext} from "../types/MyContext";
+import {pool} from "./db";
+import {logger} from "../utils/logger";
+
+export async function getOrCreateSingleInviteLinkForUserAndChat(
+    api: MyContext["api"],
+    userId: number,
+    chatId: number
+): Promise<string> {
+    // 1) Check if user_invite_links row already exists
+    const client = await pool.connect();
+    let existingLink: string | null = null;
+    try {
+        const sqlCheck = `
+      SELECT invite_link
+      FROM user_invite_links
+      WHERE user_id=$1
+        AND chat_id=$2
+      LIMIT 1
+    `;
+        const checkRes = await client.query(sqlCheck, [userId, chatId]);
+        if (checkRes.rowCount > 0) {
+            existingLink = checkRes.rows[0].invite_link;
+            logger.info(`Reusing existing invite link for user=${userId} chat=${chatId}: ${existingLink}`);
+        }
+    } finally {
+        client.release();
+    }
+
+    if (existingLink) {
+        return existingLink;
+    }
+
+    // 2) If not found => create new single-use link
+    const linkObj = await api.createChatInviteLink(chatId, {
+        member_limit: 1,
+        name: "One-time link",
+    });
+    const newLink = linkObj.invite_link;
+    logger.info(`Created new invite link for user=${userId} chatId=${chatId}: ${newLink}`);
+
+    // 3) Insert into user_invite_links
+    const client2 = await pool.connect();
+    try {
+        const sqlInsert = `
+      INSERT INTO user_invite_links (user_id, chat_id, invite_link)
+      VALUES ($1, $2, $3)
+      ON CONFLICT (user_id, chat_id) DO NOTHING
+    `;
+        await client2.query(sqlInsert, [userId, chatId, newLink]);
+    } finally {
+        client2.release();
+    }
+
+    return newLink;
+}


### PR DESCRIPTION
This pull request refactors and enhances the `broadcastComposer` functionality in the `telegram-bot/src/composers/broadcast.ts` file, focusing on modularizing the code, improving placeholder handling, and adding new utilities. The changes include replacing inline logic with reusable functions, improving error handling, and introducing support for single-use invite links.

### Code Refactoring and Modularity:
* Removed inline implementations of `generateBroadcastGroupTitle` and `getOrCreateSingleAffiliateLink`, replacing them with imports from utility and database modules (`../utils/utils`, `../db/affiliateLinks`). ([telegram-bot/src/composers/broadcast.tsL7-R31](diffhunk://#diff-89473cd2d20f1866a8a87d959dda0e55bcc9c0a85d77b3003d403a9351a62fefL7-R31), Ffc5cb76L70R40)
* Consolidated placeholder replacement logic into a new `replacePlaceholdersAndLinks` function, which handles both affiliate placeholders and single-use invite links. (Ffc5cb76L373R467)

### Placeholder Enhancements:
* Added support for `{invite:<chatID>}` placeholders, enabling the generation or reuse of single-use invite links for specific chats.
* Updated CSV placeholder descriptions to reflect the new invite placeholder functionality. (Ffc5cb76L168R268)

### Error Handling and Validation:
* Improved error handling for CSV parsing and placeholder replacement, ensuring clear error messages and logging. (Ffc5cb76L143R242, Ffc5cb76L373R467)
* Added a pre-check to ensure the bot is an admin in all chats referenced by `{invite:<chatID>}` placeholders, aborting the process if any checks fail. (Ffc5cb76L226R329)

### Code Simplification:
* Replaced redundant `else` statements with streamlined conditional logic for better readability. (Ffc5cb76L82R174, Ffc5cb76L61R151)
* Removed unused session properties like `broadcastCsvUserIds`. (Ffc5cb76L40R127)

### Utility Updates:
* Introduced helper functions like `normalizeDashes` and `escapeCsv` to handle text normalization and CSV field escaping.