### PR TITLE
add: nft api to docker compose volumes

### DIFF
--- a/docker-compose-server.yml
+++ b/docker-compose-server.yml
@@ -811,6 +811,7 @@ services:
     volumes:
       - ./swagger/ExternalSeller.yml:/usr/share/nginx/html/ExternalSeller.yaml
       - ./swagger/GameRewards.yml:/usr/share/nginx/html/GameRewards.yaml
+      - ./swagger/NFTApi.yml:/usr/share/nginx/html/NFTApi.yaml
       - ./swagger/swagger-initializer.js:/usr/share/nginx/html/swagger-initializer.js
       - ./swagger/custom.css:/usr/share/nginx/html/custom.css
       - ./swagger/home.html:/usr/share/nginx/html/home.html


### PR DESCRIPTION
This pull request adds support for serving the `NFTApi` Swagger documentation via the `nginx` service in the `docker-compose-server.yml` file.

* [`docker-compose-server.yml`](diffhunk://#diff-5db05ed311a1048890a0312a3fb1fdf109ed6e07ddba010a21d1c0fddae8c3d4R814): Added a new volume mapping for `./swagger/NFTApi.yml` to expose the `NFTApi` Swagger documentation at `/usr/share/nginx/html/NFTApi.yaml`.