### PR TITLE
fix: build lint errors

### DIFF
--- a/mini-app/src/app/api/nft/collections/[collectionId]/status/route.ts
+++ b/mini-app/src/app/api/nft/collections/[collectionId]/status/route.ts
@@ -7,8 +7,10 @@ import { nftApiMinterWalletsDB } from "@/db/modules/nftApiMinterWallets.db";
 export async function GET(request: Request, { params }: { params: { collectionId: string } }) {
   // 1) Authenticate
   const [apiKeyRecord, authError] = await getAuthenticatedNftApi(request);
-  if (authError || !apiKeyRecord) return authError;
-
+  if (authError) return authError;
+  if (!apiKeyRecord) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
   try {
     // 2) parse collectionId
     const id = parseInt(params.collectionId, 10);

--- a/mini-app/src/app/api/nft/collections/route.ts
+++ b/mini-app/src/app/api/nft/collections/route.ts
@@ -12,8 +12,10 @@ export async function POST(request: Request) {
 
   // 2) Authenticate
   const [apiKeyRecord, authError] = await getAuthenticatedNftApi(request);
-  if (authError || !apiKeyRecord) return authError; // 401 or 500
-
+  if (authError) return authError; // 401 or 500
+  if (!apiKeyRecord) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
   try {
     // 3) Parse body
 
@@ -34,7 +36,7 @@ export async function POST(request: Request) {
       coverImage: collectionData.cover_image,
       socialLinks: collectionData.social_links ?? null,
       royalties: collectionData.royalties.toString() ?? null,
-
+      lastRegisteredIndex: 0,
       // We start with no address and status "CREATING"
       address: null,
       friendlyAddress: null,

--- a/mini-app/src/app/api/nft/nfts/[nftId]/status/route.ts
+++ b/mini-app/src/app/api/nft/nfts/[nftId]/status/route.ts
@@ -7,8 +7,10 @@ import { nftApiCollectionsDB } from "@/db/modules/nftApiCollections.db"; // if y
 export async function GET(request: Request, { params }: { params: { nftId: string } }) {
   // 1) Auth
   const [apiKeyRecord, authError] = await getAuthenticatedNftApi(request);
-  if (authError || !apiKeyRecord) return authError;
-
+  if (authError) return authError;
+  if (!apiKeyRecord) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
   try {
     // parse
     const id = parseInt(params.nftId, 10);

--- a/mini-app/src/app/api/nft/nfts/first-owner/[collectionAddress]/route.ts
+++ b/mini-app/src/app/api/nft/nfts/first-owner/[collectionAddress]/route.ts
@@ -8,8 +8,10 @@ import { logger } from "@/server/utils/logger";
 export async function GET(request: Request, { params }: { params: { collectionAddress: string } }) {
   // 1) Authenticate
   const [apiKeyRecord, authError] = await getAuthenticatedNftApi(request);
-  if (authError || !apiKeyRecord) return authError;
-
+  if (authError) return authError;
+  if (!apiKeyRecord) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
   try {
     // 2) Parse path param
     const { collectionAddress } = params;

--- a/mini-app/src/app/api/nft/nfts/route.ts
+++ b/mini-app/src/app/api/nft/nfts/route.ts
@@ -14,8 +14,10 @@ export async function POST(request: Request) {
 
   // 2) Authenticate
   const [apiKeyRecord, authError] = await getAuthenticatedNftApi(request);
-  if (authError || !apiKeyRecord) return authError;
-
+  if (authError) return authError;
+  if (!apiKeyRecord) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
   try {
     // 3) Validate body
     const { walletAddress, nftData, userCallbackUrl } = await parseCreateNFTBody(request);


### PR DESCRIPTION
This pull request introduces several improvements to the authentication logic and data handling in the NFT API endpoints. The most significant changes include refining the error handling for unauthorized requests, adding a new field to the NFT collection creation process, and improving data validation in specific routes.

### Authentication Improvements:
* Updated multiple endpoints (`status/route.ts`, `collections/route.ts`, `current-owner/[collectionAddress]/route.ts`, `first-owner/[collectionAddress]/route.ts`, `nfts/route.ts`) to separate error handling for `authError` and missing `apiKeyRecord`. Unauthorized requests now return a `401` response with a JSON error message instead of a generic error. ([mini-app/src/app/api/nft/collections/[collectionId]/status/route.tsL10-R13](diffhunk://#diff-d46295697310e33f1caee768f43dc5c14722cff2d89ed079c4d104c4d069d8e4L10-R13), [[1]](diffhunk://#diff-8c52c091098bca32a448147cd2a900f47e5557501269e750988a3de22ccd5a81L15-R18) [mini-app/src/app/api/nft/nfts/[nftId]/status/route.tsL10-R13](diffhunk://#diff-a22167b66bf0d901cf2d2e86b0c2a2cde6e37c4de923079550b9be2d26403fe7L10-R13), [mini-app/src/app/api/nft/nfts/current-owner/[collectionAddress]/route.tsL14-R15](diffhunk://#diff-d412be0a69efe82309cc718473dc2fdca753e6339767ec22d8290a7793e04121L14-R15), [mini-app/src/app/api/nft/nfts/first-owner/[collectionAddress]/route.tsL11-R14](diffhunk://#diff-0fcd637374f4bba82232b78d1825502fc1b07a6ee6fcdaefe71d288724daf26cL11-R14), [[2]](diffhunk://#diff-01ceaff707d7194e15e9b23849b53b05c046b59f52fdc73b107c90ae1a8fc753L17-R20)

### Data Handling Enhancements:
* Added a `lastRegisteredIndex` field to the NFT collection creation logic to initialize collections with a default value of `0`.
* Improved validation in the `current-owner/[collectionAddress]/route.ts` endpoint by ensuring both `dbi.address` and `dbi.ownerWalletAddress` are present before processing ownership data. ([mini-app/src/app/api/nft/nfts/current-owner/[collectionAddress]/route.tsL83-R83](diffhunk://#diff-d412be0a69efe82309cc718473dc2fdca753e6339767ec22d8290a7793e04121L83-R83))

### Code Cleanup:
* Removed an outdated comment in `current-owner/[collectionAddress]/route.ts` that referenced a deprecated file path. ([mini-app/src/app/api/nft/nfts/current-owner/[collectionAddress]/route.tsL1-L2](diffhunk://#diff-d412be0a69efe82309cc718473dc2fdca753e6339767ec22d8290a7793e04121L1-L2))