### PR TITLE
add: user point detail

### DIFF
--- a/mini-app/src/app/(navigation)/my/points/AffiliateDetailCard.tsx
+++ b/mini-app/src/app/(navigation)/my/points/AffiliateDetailCard.tsx
@@ -1,0 +1,67 @@
+import CustomCard from "@/app/_components/atoms/cards/CustomCard";
+import Typography from "@/components/Typography";
+import { formatDate, formatTime } from "@/lib/DateAndTime"; // or your helpers
+import Image from "next/image";
+import { JoinOntonAffiliateScore } from "@/db/modules/usersScore.db"; // Adjust the import path as necessary
+
+type AffiliateDetailCardProps = {
+  data: JoinOntonAffiliateScore;
+};
+
+export const AffiliateDetailCard = ({ data }: AffiliateDetailCardProps) => {
+  const { userName, userFirstName, userLastName, userPhotoUrl, point, createdAt } = data;
+
+  const fullName = userName ?? ([userFirstName, userLastName].filter(Boolean).join(" ") || "Unknown User");
+
+  const created = createdAt ? new Date(createdAt) : null;
+
+  return (
+    <CustomCard className="p-2">
+      <div className="flex items-center gap-2">
+        {/* avatar / photo */}
+        <Image
+          src={userPhotoUrl || "/template-images/default.webp"}
+          alt={fullName}
+          width={65}
+          height={65}
+          className="overflow-hidden object-cover rounded-md aspect-square"
+        />
+
+        {/* left side – user and date */}
+        <div className="flex flex-col flex-1 overflow-hidden gap-[3.5px]">
+          {/* username / fullname */}
+          <Typography
+            variant="callout"
+            className="line-clamp-1"
+          >
+            {fullName}
+          </Typography>
+
+          {/* timestamp */}
+          {created && (
+            <Typography
+              variant="subheadline2"
+              className="text-gray-500 truncate"
+            >
+              {created && (
+                <Typography
+                  variant="subheadline2"
+                  className="text-gray-500 truncate"
+                >
+                  {/*  use seconds  */}
+                  {formatDate(Math.floor(created.getTime() / 1000))} | {formatTime(created)}
+                </Typography>
+              )}
+            </Typography>
+          )}
+        </div>
+
+        {/* points on the right */}
+        <div className="flex flex-col items-center">
+          <Typography variant="callout">{point}</Typography>
+          <Typography variant="caption2">Points</Typography>
+        </div>
+      </div>
+    </CustomCard>
+  );
+};

--- a/mini-app/src/app/(navigation)/my/points/[type]/details/page.tsx
+++ b/mini-app/src/app/(navigation)/my/points/[type]/details/page.tsx
@@ -15,10 +15,16 @@ import { useParams, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { FaSpinner } from "react-icons/fa6";
 import { IoInformationCircle } from "react-icons/io5";
-import { ScoreItem } from "@/db/modules/usersScore.db";
+import { JoinOntonAffiliateScore, ScoreItem } from "@/db/modules/usersScore.db";
+import { AffiliateDetailCard } from "../../AffiliateDetailCard";
 function isEventItem(item: ScoreItem): item is EventWithScoreAndReward {
   return (item as any).eventId !== undefined;
 }
+
+function isAffiliateItem(item: ScoreItem): item is JoinOntonAffiliateScore {
+  return "id" in item && !("eventId" in item);
+}
+
 const MyPointsDetailsPage = () => {
   const { type } = useParams();
   const router = useRouter();
@@ -91,7 +97,19 @@ const MyPointsDetailsPage = () => {
             ))}
         </div>
       )}
-
+      {scoreDetails.isSuccess && (
+        <div className="flex flex-col gap-2">
+          {scoreDetails.data.pages
+            .flatMap((p) => p?.items ?? [])
+            .filter(isAffiliateItem)
+            .map((row) => (
+              <AffiliateDetailCard
+                key={row.id}
+                data={row}
+              />
+            ))}
+        </div>
+      )}
       {/* Empty State */}
       {scoreDetails.isSuccess && (scoreDetails.data?.pages ?? []).flatMap((page) => page?.items ?? []).length === 0 && (
         <DataStatus

--- a/mini-app/src/app/(navigation)/my/points/page.tsx
+++ b/mini-app/src/app/(navigation)/my/points/page.tsx
@@ -28,6 +28,9 @@ export default function MyPointsPage() {
     trpc.usersScore.getTotalScoreByActivityTypeAndUserId.useQuery({
       activityType: "free_offline_event",
     });
+  const joinOntonAffiliateData = trpc.usersScore.getTotalScoreByActivityTypeAndUserId.useQuery({
+    activityType: "join_onton_affiliate",
+  });
   const { data: totalPoints, isLoading: loadingTotalPoints } = trpc.usersScore.getTotalScoreByUserId.useQuery();
   // Optionally, handle loading states here (e.g., show a spinner)
   if (!user) return null;
@@ -90,6 +93,15 @@ export default function MyPointsPage() {
               description="10 Points"
               totalPoints={Number(freeOfflineData?.total ?? 0)}
               type="free_offline_event"
+            />
+          </EventPointsGroup>
+          <EventPointsGroup title="Referals">
+            <EventPointsCard
+              eventTitle="Join ONTON Affiliate"
+              tasksCount={Number(joinOntonAffiliateData?.data?.count ?? 0)}
+              description="0.2 Points"
+              totalPoints={Number(joinOntonAffiliateData?.data?.total ?? 0)}
+              type="join_onton_affiliate"
             />
           </EventPointsGroup>
         </div>

--- a/mini-app/src/db/modules/usersScore.db.ts
+++ b/mini-app/src/db/modules/usersScore.db.ts
@@ -27,7 +27,7 @@ export type JoinOntonAffiliateScore = {
   id: number;
   point: number; // converted to number for the client
   itemId: number;
-  createdAt: Date | null; // Date is converted to string on the client
+  createdAt: string | null; // Date is converted to string on the client
   userId: number;
   userName: string | null;
   userFirstName: string | null;

--- a/mini-app/src/server/routers/UsersScore.ts
+++ b/mini-app/src/server/routers/UsersScore.ts
@@ -148,7 +148,7 @@ export const UsersScoreRouter = router({
           id: Number(r.id),
           point: Number(r.point),
           itemId: Number(r.itemId),
-          createdAt: r.createdAt,
+          createdAt: r?.createdAt?.toString() ?? null,
           userId: Number(r.userId),
           userName: r.userName,
           userFirstName: r.userFirstName,


### PR DESCRIPTION
This pull request introduces a new feature to display affiliate-related points in the "My Points" section of the application. It includes the addition of a new `AffiliateDetailCard` component, updates to the data structure and API, and integration of the affiliate points into the UI. Below are the key changes grouped by theme:

### New Component and UI Enhancements:
* Added a new `AffiliateDetailCard` component in `AffiliateDetailCard.tsx` to display details about affiliate points, including user information, timestamp, and points.
* Updated `MyPointsDetailsPage` to render `AffiliateDetailCard` for affiliate-related items by introducing a new type guard `isAffiliateItem` and filtering the data accordingly. ([mini-app/src/app/(navigation)/my/points/[type]/details/page.tsxL18-R27](diffhunk://#diff-65aacba933e9677f2d088ab1e538c66659b9be3e45b2c00fb18c454095c081aaL18-R27), [mini-app/src/app/(navigation)/my/points/[type]/details/page.tsxL94-R112](diffhunk://#diff-65aacba933e9677f2d088ab1e538c66659b9be3e45b2c00fb18c454095c081aaL94-R112))
* Enhanced the main "My Points" page to include a new "Referals" section with an `EventPointsCard` for "Join ONTON Affiliate" points.

### Data Structure and API Updates:
* Modified the `JoinOntonAffiliateScore` type to change `createdAt` from `Date | null` to `string | null` for consistent client-side handling.
* Updated the `UsersScoreRouter` to ensure `createdAt` is converted to a string before being sent to the client.

### Backend Integration:
* Added a new TRPC query in `MyPointsPage` to fetch total scores for the "join_onton_affiliate" activity type.