### PR TITLE
Staging

### DIFF
--- a/mini-app/drizzle/0095_regular_garia.sql
+++ b/mini-app/drizzle/0095_regular_garia.sql
@@ -1,0 +1,40 @@
+-- Re-usable enums
+CREATE TYPE broadcast_send_status AS ENUM ('pending', 'sent', 'failed');
+CREATE TYPE broadcast_delivery_status AS ENUM ('unknown', 'delivered', 'read');
+
+-- Root table: one row per broadcast message
+CREATE TABLE broadcast_messages (
+                                    broadcast_id        BIGSERIAL    PRIMARY KEY,
+                                    broadcaster_id      BIGINT       NOT NULL,          -- Telegram user who pressed /broadcast
+                                    source_chat_id      BIGINT       NOT NULL,
+                                    source_message_id   BIGINT       NOT NULL,
+                                    broadcast_type      TEXT         NOT NULL,          -- 'event' | 'csv'
+                                    event_uuid          UUID,                            -- nullable unless type = event
+                                    title               TEXT,                            -- cached title for dashboards
+                                    created_at          TIMESTAMPTZ  DEFAULT now()
+);
+
+-- One row per target recipient
+CREATE TABLE broadcast_users (
+                                 id                  BIGSERIAL    PRIMARY KEY,
+                                 broadcast_id        BIGINT       REFERENCES broadcast_messages(broadcast_id) ON DELETE CASCADE,
+                                 user_id             BIGINT       NOT NULL,
+                                 send_status         broadcast_send_status    DEFAULT 'pending',
+                                 delivery_status     broadcast_delivery_status DEFAULT 'unknown',
+                                 last_error          TEXT,
+                                 sent_at             TIMESTAMPTZ
+);
+
+CREATE INDEX ON broadcast_users (broadcast_id, send_status);
+-- Custom SQL migration file, put you code below! --
+
+ALTER TABLE broadcast_users
+    ADD COLUMN retry_count     INT    DEFAULT 0,
+    ADD COLUMN sent_message_id BIGINT;
+
+CREATE INDEX IF NOT EXISTS idx_bu_pending
+    ON broadcast_users (send_status, retry_count);
+
+ALTER TABLE broadcast_messages
+    ADD COLUMN message_text TEXT;       -- nullable is fine
+

--- a/mini-app/drizzle/meta/0095_snapshot.json
+++ b/mini-app/drizzle/meta/0095_snapshot.json
@@ -1,0 +1,8666 @@
+{
+  "id": "ccf69da2-7fc1-497c-91f7-cbbe4c2a665d",
+  "prevId": "a96801b0-c973-4730-90c3-c9f2b0b921b4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.affiliate_click": {
+      "name": "affiliate_click",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval\n        ('affiliate_click_id_seq'::regclass)"
+        },
+        "affiliate_lnk_id": {
+          "name": "affiliate_lnk_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "affiliate_click_affiliate_link_id_idx": {
+          "name": "affiliate_click_affiliate_link_id_idx",
+          "columns": [
+            {
+              "expression": "affiliate_lnk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "affiliate_click_user_id_idx": {
+          "name": "affiliate_click_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.affiliate_links": {
+      "name": "affiliate_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nextval\n        ('affiliate_links_id_seq'::regclass)"
+        },
+        "Item_id": {
+          "name": "Item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "affiliate_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_title": {
+          "name": "group_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link_hash": {
+          "name": "link_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_clicks": {
+          "name": "total_clicks",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_purchase": {
+          "name": "total_purchase",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "affiliator_user_id": {
+          "name": "affiliator_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now\n        ()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "affiliate_links_link_hash_key": {
+          "name": "affiliate_links_link_hash_key",
+          "columns": [
+            {
+              "expression": "link_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "affiliate_links_Item_id_item_type_idx": {
+          "name": "affiliate_links_Item_id_item_type_idx",
+          "columns": [
+            {
+              "expression": "Item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "affiliate_links_affiliator_user_id_idx": {
+          "name": "affiliate_links_affiliator_user_id_idx",
+          "columns": [
+            {
+              "expression": "affiliator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "affiliate_links_creator_user_id_idx": {
+          "name": "affiliate_links_creator_user_id_idx",
+          "columns": [
+            {
+              "expression": "creator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.airdrop_routines": {
+      "name": "airdrop_routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "airdrop_event_id_idx": {
+          "name": "airdrop_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "airdrop_user_id_idx": {
+          "name": "airdrop_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "airdrop_status_idx": {
+          "name": "airdrop_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "airdrop_created_at_idx": {
+          "name": "airdrop_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "airdrop_updated_at_idx": {
+          "name": "airdrop_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "airdrop_routines_event_id_events_event_id_fk": {
+          "name": "airdrop_routines_event_id_events_event_id_fk",
+          "tableFrom": "airdrop_routines",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "airdrop_routines_user_id_users_user_id_fk": {
+          "name": "airdrop_routines_user_id_users_user_id_fk",
+          "tableFrom": "airdrop_routines",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.callback_task_runs": {
+      "name": "callback_task_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_uuid": {
+          "name": "run_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "callback_task_id": {
+          "name": "callback_task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "callback_task_run_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "callback_task_runs_run_uuid_idx": {
+          "name": "callback_task_runs_run_uuid_idx",
+          "columns": [
+            {
+              "expression": "run_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_task_runs_callback_task_id_idx": {
+          "name": "callback_task_runs_callback_task_id_idx",
+          "columns": [
+            {
+              "expression": "callback_task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_task_runs_run_uuid_unique": {
+          "name": "callback_task_runs_run_uuid_unique",
+          "columns": [
+            {
+              "expression": "run_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_task_runs_next_run_at_idx": {
+          "name": "callback_task_runs_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "callback_task_runs_callback_task_id_callback_tasks_id_fk": {
+          "name": "callback_task_runs_callback_task_id_callback_tasks_id_fk",
+          "tableFrom": "callback_task_runs",
+          "columnsFrom": [
+            "callback_task_id"
+          ],
+          "tableTo": "callback_tasks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.callback_tasks": {
+      "name": "callback_tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_uuid": {
+          "name": "task_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "step_name": {
+          "name": "step_name",
+          "type": "step_name_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_name": {
+          "name": "api_name",
+          "type": "api_name_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_function": {
+          "name": "task_function",
+          "type": "task_function_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload_template": {
+          "name": "payload_template",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "http_method_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'POST'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "retry_policy": {
+          "name": "retry_policy",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"max_attempt\":5,\"wait_for_retry\":1000}'::json"
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "item_type_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "callback_tasks_task_uuid_idx": {
+          "name": "callback_tasks_task_uuid_idx",
+          "columns": [
+            {
+              "expression": "task_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_tasks_step_name_idx": {
+          "name": "callback_tasks_step_name_idx",
+          "columns": [
+            {
+              "expression": "step_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_tasks_api_name_idx": {
+          "name": "callback_tasks_api_name_idx",
+          "columns": [
+            {
+              "expression": "api_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_tasks_item_type_idx": {
+          "name": "callback_tasks_item_type_idx",
+          "columns": [
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_tasks_item_id_idx": {
+          "name": "callback_tasks_item_id_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "callback_tasks_task_uuid_unique": {
+          "name": "callback_tasks_task_uuid_unique",
+          "columns": [
+            {
+              "expression": "task_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.coupon_definition": {
+      "name": "coupon_definition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_type": {
+          "name": "coupon_type",
+          "type": "coupon_definition_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "coupon_definition_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "numeric(8, 3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "coupon_definition_event_uuid_idx": {
+          "name": "coupon_definition_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_definition_count_idx": {
+          "name": "coupon_definition_count_idx",
+          "columns": [
+            {
+              "expression": "count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_definition_start_date_end_date_idx": {
+          "name": "coupon_definition_start_date_end_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_definition_status_idx": {
+          "name": "coupon_definition_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_definition_type_idx": {
+          "name": "coupon_definition_type_idx",
+          "columns": [
+            {
+              "expression": "coupon_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_definition_used_idx": {
+          "name": "coupon_definition_used_idx",
+          "columns": [
+            {
+              "expression": "used",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "coupon_definition_event_uuid_events_event_uuid_fk": {
+          "name": "coupon_definition_event_uuid_events_event_uuid_fk",
+          "tableFrom": "coupon_definition",
+          "columnsFrom": [
+            "event_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.coupon_items": {
+      "name": "coupon_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_definition_id": {
+          "name": "coupon_definition_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "coupon_status": {
+          "name": "coupon_status",
+          "type": "coupon_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unused'"
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": null
+        },
+        "message_status": {
+          "name": "message_status",
+          "type": "message_send_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "send_attempts": {
+          "name": "send_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_send_error": {
+          "name": "last_send_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_send_at": {
+          "name": "last_send_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "coupon_items_event_uuid_idx": {
+          "name": "coupon_items_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_items_code_idx": {
+          "name": "coupon_items_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_items_coupon_status_idx": {
+          "name": "coupon_items_coupon_status_idx",
+          "columns": [
+            {
+              "expression": "coupon_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_items_group_id_idx": {
+          "name": "coupon_items_group_id_idx",
+          "columns": [
+            {
+              "expression": "coupon_definition_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_items_event_uuid_code_uq": {
+          "name": "coupon_items_event_uuid_code_uq",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_items_message_status_idx": {
+          "name": "coupon_items_message_status_idx",
+          "columns": [
+            {
+              "expression": "message_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "coupon_items_invited_user_id_idx": {
+          "name": "coupon_items_invited_user_id_idx",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "coupon_items_event_uuid_events_event_uuid_fk": {
+          "name": "coupon_items_event_uuid_events_event_uuid_fk",
+          "tableFrom": "coupon_items",
+          "columnsFrom": [
+            "event_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        },
+        "coupon_items_coupon_definition_id_coupon_definition_id_fk": {
+          "name": "coupon_items_coupon_definition_id_coupon_definition_id_fk",
+          "tableFrom": "coupon_items",
+          "columnsFrom": [
+            "coupon_definition_id"
+          ],
+          "tableTo": "coupon_definition",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_categories": {
+      "name": "event_categories",
+      "schema": "",
+      "columns": {
+        "category_id": {
+          "name": "category_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "event_categories_name_idx": {
+          "name": "event_categories_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_fields": {
+      "name": "event_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "placeholder": {
+          "name": "placeholder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_place": {
+          "name": "order_place",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "eventf_title_idx": {
+          "name": "eventf_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "eventf_type_idx": {
+          "name": "eventf_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "eventf_event_id_idx": {
+          "name": "eventf_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "eventf_updated_at_idx": {
+          "name": "eventf_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_fields_event_id_events_event_id_fk": {
+          "name": "event_fields_event_id_events_event_id_fk",
+          "tableFrom": "event_fields",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_payment_info": {
+      "name": "event_payment_info",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "payment_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recipient_address": {
+          "name": "recipient_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bought_capacity": {
+          "name": "bought_capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_type": {
+          "name": "ticket_type",
+          "type": "ticket_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticket_image": {
+          "name": "ticket_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticket_video": {
+          "name": "ticket_video",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_address": {
+          "name": "collection_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizer_payment_status": {
+          "name": "organizer_payment_status",
+          "type": "organizer_payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_payed'"
+        },
+        "ticket_activity_id": {
+          "name": "ticket_activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "event_payment_info_event_uuid_index": {
+          "name": "event_payment_info_event_uuid_index",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "event_event_uuid_idx": {
+          "name": "event_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_payment_info_event_uuid_events_event_uuid_fk": {
+          "name": "event_payment_info_event_uuid_events_event_uuid_fk",
+          "tableFrom": "event_payment_info",
+          "columnsFrom": [
+            "event_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_poa_results": {
+      "name": "event_poa_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poa_id": {
+          "name": "poa_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poa_answer": {
+          "name": "poa_answer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_poa_result_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replied_at": {
+          "name": "replied_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_poa_results_user_id_users_user_id_fk": {
+          "name": "event_poa_results_user_id_users_user_id_fk",
+          "tableFrom": "event_poa_results",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_poa_results_poa_id_event_poa_triggers_id_fk": {
+          "name": "event_poa_results_poa_id_event_poa_triggers_id_fk",
+          "tableFrom": "event_poa_results",
+          "columnsFrom": [
+            "poa_id"
+          ],
+          "tableTo": "event_poa_triggers",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "event_poa_results_event_id_events_event_id_fk": {
+          "name": "event_poa_results_event_id_events_event_id_fk",
+          "tableFrom": "event_poa_results",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_poa_triggers": {
+      "name": "event_poa_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poa_order": {
+          "name": "poa_order",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_of_sent": {
+          "name": "count_of_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "count_of_success": {
+          "name": "count_of_success",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poa_type": {
+          "name": "poa_type",
+          "type": "event_trigger_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'simple'"
+        },
+        "status": {
+          "name": "status",
+          "type": "event_trigger_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_user_id": {
+          "name": "creator_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_poa_triggers_event_id_events_event_id_fk": {
+          "name": "event_poa_triggers_event_id_events_event_id_fk",
+          "tableFrom": "event_poa_triggers",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.event_registrants": {
+      "name": "event_registrants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "registrant_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "register_info": {
+          "name": "register_info",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "registrant_uuid": {
+          "name": "registrant_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid\n        ()"
+        },
+        "telegram_invite_link": {
+          "name": "telegram_invite_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "event_registrants_event_uuid_user_id_index": {
+          "name": "event_registrants_event_uuid_user_id_index",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "event_registrants_user_id_users_user_id_fk": {
+          "name": "event_registrants_user_id_users_user_id_fk",
+          "tableFrom": "event_registrants",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_registrants_registrant_uuid_unique": {
+          "name": "event_registrants_registrant_uuid_unique",
+          "columns": [
+            "registrant_uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "society_hub": {
+          "name": "society_hub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "society_hub_id": {
+          "name": "society_hub_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbt_collection_address": {
+          "name": "sbt_collection_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_phrase": {
+          "name": "secret_phrase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticketToCheckIn": {
+          "name": "ticketToCheckIn",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "participation_type": {
+          "name": "participation_type",
+          "type": "event_participation_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'online'"
+        },
+        "city_id": {
+          "name": "city_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts_reward_image": {
+          "name": "ts_reward_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts_reward_video": {
+          "name": "ts_reward_video",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_telegram_group": {
+          "name": "event_telegram_group",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_registration": {
+          "name": "has_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "has_approval": {
+          "name": "has_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_waiting_list": {
+          "name": "has_waiting_list",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_payment": {
+          "name": "has_payment",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "moderation_message_id": {
+          "name": "moderation_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "events_event_uuid_idx": {
+          "name": "events_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_type_idx": {
+          "name": "events_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_title_idx": {
+          "name": "events_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_wallet_address_idx": {
+          "name": "events_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_society_hub_idx": {
+          "name": "events_society_hub_idx",
+          "columns": [
+            {
+              "expression": "society_hub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_start_date_idx": {
+          "name": "events_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_end_date_idx": {
+          "name": "events_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_owner_idx": {
+          "name": "events_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_hidden_idx": {
+          "name": "events_hidden_idx",
+          "columns": [
+            {
+              "expression": "hidden",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_created_at_idx": {
+          "name": "events_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_updated_at_idx": {
+          "name": "events_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_participation_type_idx": {
+          "name": "events_participation_type_idx",
+          "columns": [
+            {
+              "expression": "participation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_event_uuid_index": {
+          "name": "events_event_uuid_index",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_moderation_message_id_idx": {
+          "name": "events_moderation_message_id_idx",
+          "columns": [
+            {
+              "expression": "moderation_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_category_id_idx": {
+          "name": "events_category_id_idx",
+          "columns": [
+            {
+              "expression": "category_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "events_owner_users_user_id_fk": {
+          "name": "events_owner_users_user_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "owner"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "events_city_id_giata_city_id_fk": {
+          "name": "events_city_id_giata_city_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "city_id"
+          ],
+          "tableTo": "giata_city",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "events_country_id_giata_city_id_fk": {
+          "name": "events_country_id_giata_city_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "tableTo": "giata_city",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "events_category_id_event_categories_category_id_fk": {
+          "name": "events_category_id_event_categories_category_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "tableTo": "event_categories",
+          "columnsTo": [
+            "category_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.game_leaderboard": {
+      "name": "game_leaderboard",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_user_id": {
+          "name": "host_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "telegram_user_id": {
+          "name": "telegram_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tournament_id": {
+          "name": "tournament_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_tournament_id": {
+          "name": "host_tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_created": {
+          "name": "reward_created",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "notification_received": {
+          "name": "notification_received",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "has_claimed": {
+          "name": "has_claimed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "gl_host_tournament_idx": {
+          "name": "gl_host_tournament_idx",
+          "columns": [
+            {
+              "expression": "host_tournament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "gl_telegram_user_idx": {
+          "name": "gl_telegram_user_idx",
+          "columns": [
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "unique_user_tournament": {
+          "name": "unique_user_tournament",
+          "columns": [
+            {
+              "expression": "host_tournament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "telegram_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "game_leaderboard_telegram_user_id_users_user_id_fk": {
+          "name": "game_leaderboard_telegram_user_id_users_user_id_fk",
+          "tableFrom": "game_leaderboard",
+          "columnsFrom": [
+            "telegram_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "game_leaderboard_tournament_id_tournaments_id_fk": {
+          "name": "game_leaderboard_tournament_id_tournaments_id_fk",
+          "tableFrom": "game_leaderboard",
+          "columnsFrom": [
+            "tournament_id"
+          ],
+          "tableTo": "tournaments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "game_leaderboard_game_id_games_id_fk": {
+          "name": "game_leaderboard_game_id_games_id_fk",
+          "tableFrom": "game_leaderboard",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "tableTo": "games",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_game_id": {
+          "name": "host_game_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_game_json": {
+          "name": "raw_game_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "games_host_game_id_unique": {
+          "name": "games_host_game_id_unique",
+          "columns": [
+            {
+              "expression": "host_game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "games_name_idx": {
+          "name": "games_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.giata_city": {
+      "name": "giata_city",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insert_date": {
+          "name": "insert_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "abbreviated_code": {
+          "name": "abbreviated_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "giata_code": {
+          "name": "giata_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "giata_city_title_idx": {
+          "name": "giata_city_title_idx",
+          "columns": [
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "giata_city_parent_id_idx": {
+          "name": "giata_city_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "giata_city_insert_date_idx": {
+          "name": "giata_city_insert_date_idx",
+          "columns": [
+            {
+              "expression": "insert_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "giata_city_abbreviated_code_idx": {
+          "name": "giata_city_abbreviated_code_idx",
+          "columns": [
+            {
+              "expression": "abbreviated_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "giata_city_giata_code_idx": {
+          "name": "giata_city_giata_code_idx",
+          "columns": [
+            {
+              "expression": "giata_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.moderation_log": {
+      "name": "moderation_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "moderator_user_id": {
+          "name": "moderator_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_owner_id": {
+          "name": "event_owner_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "moderation_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_text": {
+          "name": "custom_text",
+          "type": "varchar(4096)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "moderation_log_moderator_user_id_idx": {
+          "name": "moderation_log_moderator_user_id_idx",
+          "columns": [
+            {
+              "expression": "moderator_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "moderation_log_event_uuid_idx": {
+          "name": "moderation_log_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "moderation_log_action_idx": {
+          "name": "moderation_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "moderation_log_event_owner_id_idx": {
+          "name": "moderation_log_event_owner_id_idx",
+          "columns": [
+            {
+              "expression": "event_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nft_api_collections": {
+      "name": "nft_api_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "minter_wallet_id": {
+          "name": "minter_wallet_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image": {
+          "name": "cover_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friendly_address": {
+          "name": "friendly_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "nft_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATING'"
+        },
+        "royalties": {
+          "name": "royalties",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_registered_index": {
+          "name": "last_registered_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": -1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nft_api_collections_address_idx": {
+          "name": "nft_api_collections_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nft_api_collections_minter_idx": {
+          "name": "nft_api_collections_minter_idx",
+          "columns": [
+            {
+              "expression": "minter_wallet_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nft_api_collections_apikey_idx": {
+          "name": "nft_api_collections_apikey_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nft_api_items": {
+      "name": "nft_api_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_url": {
+          "name": "content_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buttons": {
+          "name": "buttons",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friendly_address": {
+          "name": "friendly_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nft_index": {
+          "name": "nft_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_wallet_address": {
+          "name": "owner_wallet_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "nft_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CREATING'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nft_api_items_collection_id_idx": {
+          "name": "nft_api_items_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nft_api_items_address_idx": {
+          "name": "nft_api_items_address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nft_api_items_owner_idx": {
+          "name": "nft_api_items_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nft_api_keys": {
+      "name": "nft_api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nft_api_keys_api_key_idx": {
+          "name": "nft_api_keys_api_key_idx",
+          "columns": [
+            {
+              "expression": "api_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nft_api_minter_wallets": {
+      "name": "nft_api_minter_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friendly_name": {
+          "name": "friendly_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mnemonic": {
+          "name": "mnemonic",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nft_api_minter_wallets_wallet_address_idx": {
+          "name": "nft_api_minter_wallets_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "nft_api_minter_wallets_api_key_id_idx": {
+          "name": "nft_api_minter_wallets_api_key_id_idx",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.nft_items": {
+      "name": "nft_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_uuid": {
+          "name": "order_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nft_address": {
+          "name": "nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "nft_items_order_uuid_index": {
+          "name": "nft_items_order_uuid_index",
+          "columns": [
+            {
+              "expression": "order_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "nft_items_order_uuid_orders_uuid_fk": {
+          "name": "nft_items_order_uuid_orders_uuid_fk",
+          "tableFrom": "nft_items",
+          "columnsFrom": [
+            "order_uuid"
+          ],
+          "tableTo": "orders",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "nft_items_owner_users_user_id_fk": {
+          "name": "nft_items_owner_users_user_id_fk",
+          "tableFrom": "nft_items",
+          "columnsFrom": [
+            "owner"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UNKNOWN'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desc": {
+          "name": "desc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "link": {
+          "name": "link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_time_out": {
+          "name": "action_time_out",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_reply": {
+          "name": "action_reply",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "additional_data": {
+          "name": "additional_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "notification_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'WAITING_TO_SEND'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "notification_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UNKNOWN'"
+        }
+      },
+      "indexes": {
+        "notifications_user_id_type_item_id_item_type_key": {
+          "name": "notifications_user_id_type_item_id_item_type_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_user_id_idx": {
+          "name": "notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_expires_at_idx": {
+          "name": "notifications_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_item_id_item_type_idx": {
+          "name": "notifications_item_id_item_type_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_status_idx": {
+          "name": "notifications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "notifications_type_idx": {
+          "name": "notifications_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.onton_setting": {
+      "name": "onton_setting",
+      "schema": "",
+      "columns": {
+        "env": {
+          "name": "env",
+          "type": "development_environment",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "var": {
+          "name": "var",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "onton_setting_env_var_pk": {
+          "name": "onton_setting_env_var_pk",
+          "columns": [
+            "env",
+            "var"
+          ]
+        },
+        "onto_setting_pk": {
+          "name": "onto_setting_pk",
+          "columns": [
+            "env",
+            "var"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.orders": {
+      "name": "orders",
+      "schema": "",
+      "columns": {
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_price": {
+          "name": "total_price",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "payment_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "order_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order_type": {
+          "name": "order_type",
+          "type": "order_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_address": {
+          "name": "owner_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trx_hash": {
+          "name": "trx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "utm_source": {
+          "name": "utm_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "orders_event_uuid_idx": {
+          "name": "orders_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "orders_user_id_idx": {
+          "name": "orders_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "orders_state_idx": {
+          "name": "orders_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "orders_owner_address_idx": {
+          "name": "orders_owner_address_idx",
+          "columns": [
+            {
+              "expression": "owner_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "orders_coupon_id_idx": {
+          "name": "orders_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "orders_wallet_address_idx": {
+          "name": "orders_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "owner_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "orders_event_uuid_events_event_uuid_fk": {
+          "name": "orders_event_uuid_events_event_uuid_fk",
+          "tableFrom": "orders",
+          "columnsFrom": [
+            "event_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "orders_user_id_users_user_id_fk": {
+          "name": "orders_user_id_users_user_id_fk",
+          "tableFrom": "orders",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "orders_coupon_id_coupon_items_id_fk": {
+          "name": "orders_coupon_id_coupon_items_id_fk",
+          "tableFrom": "orders",
+          "columnsFrom": [
+            "coupon_id"
+          ],
+          "tableTo": "coupon_items",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.play2win_campaigns": {
+      "name": "play2win_campaigns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "campaign_type": {
+          "name": "campaign_type",
+          "type": "play2win_campaign_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "play2win_campaigns_user_campaign_idx": {
+          "name": "play2win_campaigns_user_campaign_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "campaign_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.rewards": {
+      "name": "rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "visitor_id": {
+          "name": "visitor_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "reward_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "try_count": {
+          "name": "try_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "reward_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_start_date": {
+          "name": "event_start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_end_date": {
+          "name": "event_end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "ton_society_status": {
+          "name": "ton_society_status",
+          "type": "ton_society_status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'NOT_CLAIMED'"
+        }
+      },
+      "indexes": {
+        "rewards_visitor_id_idx": {
+          "name": "rewards_visitor_id_idx",
+          "columns": [
+            {
+              "expression": "visitor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rewards_type_idx": {
+          "name": "rewards_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rewards_status_idx": {
+          "name": "rewards_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rewards_created_at_idx": {
+          "name": "rewards_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "rewards_updated_at_idx": {
+          "name": "rewards_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "rewards_visitor_id_visitors_id_fk": {
+          "name": "rewards_visitor_id_visitors_id_fk",
+          "tableFrom": "rewards",
+          "columnsFrom": [
+            "visitor_id"
+          ],
+          "tableTo": "visitors",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.sbt_reward_collections": {
+      "name": "sbt_reward_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "hubID": {
+          "name": "hubID",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hubName": {
+          "name": "hubName",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "videoLink": {
+          "name": "videoLink",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageLink": {
+          "name": "imageLink",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.side_events": {
+      "name": "side_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "main_uuid": {
+          "name": "main_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_uuid": {
+          "name": "side_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "side_events_main_uuid_events_event_uuid_fk": {
+          "name": "side_events_main_uuid_events_event_uuid_fk",
+          "tableFrom": "side_events",
+          "columnsFrom": [
+            "main_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "side_events_side_uuid_events_event_uuid_fk": {
+          "name": "side_events_side_uuid_events_event_uuid_fk",
+          "tableFrom": "side_events",
+          "columnsFrom": [
+            "side_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "side_events_main_uuid_side_uuid_unique": {
+          "name": "side_events_main_uuid_side_uuid_unique",
+          "columns": [
+            "main_uuid",
+            "side_uuid"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.nft_collection_snapshot": {
+      "name": "nft_collection_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "snapshot_runtime": {
+          "name": "snapshot_runtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_address": {
+          "name": "collection_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nft_address": {
+          "name": "nft_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_address": {
+          "name": "owner_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_claimed'"
+        },
+        "nft_index": {
+          "name": "nft_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_balance": {
+          "name": "owner_balance",
+          "type": "numeric(30, 9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "snapshot_runtime_nft_idx": {
+          "name": "snapshot_runtime_nft_idx",
+          "columns": [
+            {
+              "expression": "snapshot_runtime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "nft_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.special_guests": {
+      "name": "special_guests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surname": {
+          "name": "surname",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_groups": {
+      "name": "task_groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbt_id": {
+          "name": "sbt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "task_groups_sbt_id_task_sbt_id_fk": {
+          "name": "task_groups_sbt_id_task_sbt_id_fk",
+          "tableFrom": "task_groups",
+          "columnsFrom": [
+            "sbt_id"
+          ],
+          "tableTo": "task_sbt",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.task_sbt": {
+      "name": "task_sbt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sbt_title": {
+          "name": "sbt_title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sbt_description": {
+          "name": "sbt_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbt_image_url": {
+          "name": "sbt_image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbt_reward_url": {
+          "name": "sbt_reward_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbt_reward_link": {
+          "name": "sbt_reward_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users_task": {
+      "name": "users_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "task_user_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'need_to_check'"
+        },
+        "point_status": {
+          "name": "point_status",
+          "type": "task_user_point_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_allocated'"
+        },
+        "task_sbt": {
+          "name": "task_sbt",
+          "type": "task_user_sbt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'has_not_sbt'"
+        },
+        "group_sbt": {
+          "name": "group_sbt",
+          "type": "task_user_sbt_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'has_not_sbt'"
+        },
+        "custom_data": {
+          "name": "custom_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_task_user_id_users_user_id_fk": {
+          "name": "users_task_user_id_users_user_id_fk",
+          "tableFrom": "users_task",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "users_task_task_id_tasks_id_fk": {
+          "name": "users_task_task_id_tasks_id_fk",
+          "tableFrom": "users_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "tableTo": "tasks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_date": {
+          "name": "open_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_date": {
+          "name": "close_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "open_time": {
+          "name": "open_time",
+          "type": "time(0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_time": {
+          "name": "close_time",
+          "type": "time(0)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "period": {
+          "name": "period",
+          "type": "task_period",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "period_interval": {
+          "name": "period_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "task_type": {
+          "name": "task_type",
+          "type": "task_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'affiliation'"
+        },
+        "reward_point": {
+          "name": "reward_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_sbt": {
+          "name": "has_sbt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_group_sbt": {
+          "name": "has_group_sbt",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sbt_id": {
+          "name": "sbt_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_connected_item": {
+          "name": "task_connected_item",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_connected_item_types": {
+          "name": "task_connected_item_types",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "json_for_checker": {
+          "name": "json_for_checker",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tasks_group_id_task_groups_id_fk": {
+          "name": "tasks_group_id_task_groups_id_fk",
+          "tableFrom": "tasks",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "tableTo": "task_groups",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        },
+        "tasks_sbt_id_task_sbt_id_fk": {
+          "name": "tasks_sbt_id_task_sbt_id_fk",
+          "tableFrom": "tasks",
+          "columnsFrom": [
+            "sbt_id"
+          ],
+          "tableTo": "task_sbt",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "cascade",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "telegram": {
+          "name": "telegram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company": {
+          "name": "company",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_uuid": {
+          "name": "order_uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "event_ticket_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nft_address": {
+          "name": "nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_ticket_id": {
+          "name": "event_ticket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "tickets_name_idx": {
+          "name": "tickets_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_telegram_idx": {
+          "name": "tickets_telegram_idx",
+          "columns": [
+            {
+              "expression": "telegram",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_company_idx": {
+          "name": "tickets_company_idx",
+          "columns": [
+            {
+              "expression": "company",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_order_uuid_idx": {
+          "name": "tickets_order_uuid_idx",
+          "columns": [
+            {
+              "expression": "order_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_status_idx": {
+          "name": "tickets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_nft_address_idx": {
+          "name": "tickets_nft_address_idx",
+          "columns": [
+            {
+              "expression": "nft_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_event_uuid_idx": {
+          "name": "tickets_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_ticket_id_idx": {
+          "name": "tickets_ticket_id_idx",
+          "columns": [
+            {
+              "expression": "event_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_user_id_idx": {
+          "name": "tickets_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_created_at_idx": {
+          "name": "tickets_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tickets_updated_at_idx": {
+          "name": "tickets_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tickets_order_uuid_orders_uuid_fk": {
+          "name": "tickets_order_uuid_orders_uuid_fk",
+          "tableFrom": "tickets",
+          "columnsFrom": [
+            "order_uuid"
+          ],
+          "tableTo": "orders",
+          "columnsTo": [
+            "uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tickets_event_uuid_events_event_uuid_fk": {
+          "name": "tickets_event_uuid_events_event_uuid_fk",
+          "tableFrom": "tickets",
+          "columnsFrom": [
+            "event_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tickets_event_ticket_id_event_payment_info_id_fk": {
+          "name": "tickets_event_ticket_id_event_payment_info_id_fk",
+          "tableFrom": "tickets",
+          "columnsFrom": [
+            "event_ticket_id"
+          ],
+          "tableTo": "event_payment_info",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tickets_user_id_users_user_id_fk": {
+          "name": "tickets_user_id_users_user_id_fk",
+          "tableFrom": "tickets",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_claim_onion": {
+      "name": "token_campaign_claim_onion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(66)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_type": {
+          "name": "wallet_type",
+          "type": "wallet_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ton_proof": {
+          "name": "ton_proof",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshot_runtime": {
+          "name": "snapshot_runtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platinum_nft_count": {
+          "name": "platinum_nft_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "gold_nft_count": {
+          "name": "gold_nft_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "silver_nft_count": {
+          "name": "silver_nft_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "bronze_nft_count": {
+          "name": "bronze_nft_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "onions_from_platinum": {
+          "name": "onions_from_platinum",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "onions_from_gold": {
+          "name": "onions_from_gold",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "onions_from_silver": {
+          "name": "onions_from_silver",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "onions_from_bronze": {
+          "name": "onions_from_bronze",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "onions_from_score": {
+          "name": "onions_from_score",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "total_onions": {
+          "name": "total_onions",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "claim_wallet_unique": {
+          "name": "claim_wallet_unique",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "claim_user_idx": {
+          "name": "claim_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "token_campaign_claim_onion_user_id_users_user_id_fk": {
+          "name": "token_campaign_claim_onion_user_id_users_user_id_fk",
+          "tableFrom": "token_campaign_claim_onion",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_eligible_users": {
+      "name": "token_campaign_eligible_users",
+      "schema": "",
+      "columns": {
+        "user_telegram_id": {
+          "name": "user_telegram_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_merge_transactions": {
+      "name": "token_campaign_merge_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_hash": {
+          "name": "transaction_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gold_nft_address": {
+          "name": "gold_nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "silver_nft_address": {
+          "name": "silver_nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bronze_nft_address": {
+          "name": "bronze_nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platinum_nft_address": {
+          "name": "platinum_nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "extra_data": {
+          "name": "extra_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_nft_collections": {
+      "name": "token_campaign_nft_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_type": {
+          "name": "campaign_type",
+          "type": "campaign_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "probability_weight": {
+          "name": "probability_weight",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image": {
+          "name": "image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata_url": {
+          "name": "metadata_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_meta_data": {
+          "name": "item_meta_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "collection_meta_data": {
+          "name": "collection_meta_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sales_volume": {
+          "name": "sales_volume",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "sales_count": {
+          "name": "sales_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "last_registered_item_index": {
+          "name": "last_registered_item_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sorting": {
+          "name": "sorting",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_for_sale": {
+          "name": "is_for_sale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "address_idx": {
+          "name": "address_idx",
+          "columns": [
+            {
+              "expression": "address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "name_idx": {
+          "name": "name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "last_registered_item_index_idx": {
+          "name": "last_registered_item_index_idx",
+          "columns": [
+            {
+              "expression": "last_registered_item_index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_nft_items": {
+      "name": "token_campaign_nft_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "campaign_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nft_address": {
+          "name": "nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "index": {
+          "name": "index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_address": {
+          "name": "collection_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "merge_status": {
+          "name": "merge_status",
+          "type": "merge_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_allowed_to_merge'"
+        },
+        "merged_into_nft_address": {
+          "name": "merged_into_nft_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "merged_into_nft_index": {
+          "name": "merged_into_nft_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "burn_trx_hash": {
+          "name": "burn_trx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "token_campaign_nft_items_owner_users_user_id_fk": {
+          "name": "token_campaign_nft_items_owner_users_user_id_fk",
+          "tableFrom": "token_campaign_nft_items",
+          "columnsFrom": [
+            "owner"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_orders": {
+      "name": "token_campaign_orders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "spin_package_id": {
+          "name": "spin_package_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_price": {
+          "name": "final_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_price": {
+          "name": "default_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "order_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'new'"
+        },
+        "payment_type": {
+          "name": "payment_type",
+          "type": "payment_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affiliate_hash": {
+          "name": "affiliate_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trx_hash": {
+          "name": "trx_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "spin_package_id_idx": {
+          "name": "spin_package_id_idx",
+          "columns": [
+            {
+              "expression": "spin_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "trx_hash_idx": {
+          "name": "trx_hash_idx",
+          "columns": [
+            {
+              "expression": "trx_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "token_campaign_orders_uuid_idxe": {
+          "name": "token_campaign_orders_uuid_idxe",
+          "columns": [
+            {
+              "expression": "uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "wallet_address_idx": {
+          "name": "wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "token_campaign_orders_user_id_users_user_id_fk": {
+          "name": "token_campaign_orders_user_id_users_user_id_fk",
+          "tableFrom": "token_campaign_orders",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_spin_packages": {
+      "name": "token_campaign_spin_packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "campaign_type": {
+          "name": "campaign_type",
+          "type": "campaign_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sold_items_count": {
+          "name": "sold_items_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "auto_activation_date": {
+          "name": "auto_activation_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price": {
+          "name": "price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'100.00'"
+        },
+        "currency": {
+          "name": "currency",
+          "type": "payment_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_deactivation_date": {
+          "name": "auto_deactivation_date",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spin_count": {
+          "name": "spin_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_for_sale": {
+          "name": "is_for_sale",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "tcps_name_idx": {
+          "name": "tcps_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcps_active_idx": {
+          "name": "tcps_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcps_auto_activation_date_idx": {
+          "name": "tcps_auto_activation_date_idx",
+          "columns": [
+            {
+              "expression": "auto_activation_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcps_auto_deactivation_date_idx": {
+          "name": "tcps_auto_deactivation_date_idx",
+          "columns": [
+            {
+              "expression": "auto_deactivation_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcps_is_for_sale_idx": {
+          "name": "tcps_is_for_sale_idx",
+          "columns": [
+            {
+              "expression": "is_for_sale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_user_collections": {
+      "name": "token_campaign_user_collections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method_detail_id": {
+          "name": "method_detail_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "tcuc_user_id_idx": {
+          "name": "tcuc_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcuc_collection_id_idx": {
+          "name": "tcuc_collection_id_idx",
+          "columns": [
+            {
+              "expression": "collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "token_campaign_user_collections_user_id_users_user_id_fk": {
+          "name": "token_campaign_user_collections_user_id_users_user_id_fk",
+          "tableFrom": "token_campaign_user_collections",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.token_campaign_user_spins": {
+      "name": "token_campaign_user_spins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spin_package_id": {
+          "name": "spin_package_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spin_index": {
+          "name": "spin_index",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nft_collection_id": {
+          "name": "nft_collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_minted": {
+          "name": "is_minted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "spin_type": {
+          "name": "spin_type",
+          "type": "spin_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'normal'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "tcus_user_id_idx": {
+          "name": "tcus_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcus_spin_package_id_idx": {
+          "name": "tcus_spin_package_id_idx",
+          "columns": [
+            {
+              "expression": "spin_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tcus_nft_collection_id_idx": {
+          "name": "tcus_nft_collection_id_idx",
+          "columns": [
+            {
+              "expression": "nft_collection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "token_campaign_user_spins_user_id_users_user_id_fk": {
+          "name": "token_campaign_user_spins_user_id_users_user_id_fk",
+          "tableFrom": "token_campaign_user_spins",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tournaments": {
+      "name": "tournaments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_tournament_id": {
+          "name": "host_tournament_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host_tournament_guid": {
+          "name": "host_tournament_guid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "tournament_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "create_date": {
+          "name": "create_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players_count": {
+          "name": "players_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "entry_fee": {
+          "name": "entry_fee",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ton_entry_type": {
+          "name": "ton_entry_type",
+          "type": "tournament_entry_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ton_tournament_address": {
+          "name": "ton_tournament_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prize_pool_status": {
+          "name": "prize_pool_status",
+          "type": "prize_pool_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prize_type": {
+          "name": "prize_type",
+          "type": "prize_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_prize_pool": {
+          "name": "current_prize_pool",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_id": {
+          "name": "activity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts_reward_image": {
+          "name": "ts_reward_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ts_reward_video": {
+          "name": "ts_reward_video",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tournament_link": {
+          "name": "tournament_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_host_json": {
+          "name": "raw_host_json",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_link": {
+          "name": "reward_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "tournaments_host_tournament_id_unique": {
+          "name": "tournaments_host_tournament_id_unique",
+          "columns": [
+            {
+              "expression": "host_tournament_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tournaments_game_id_idx": {
+          "name": "tournaments_game_id_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tournaments_created_by_user_id_idx": {
+          "name": "tournaments_created_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tournaments_owner_idx": {
+          "name": "tournaments_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tournaments_state_idx": {
+          "name": "tournaments_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "tournaments_activity_id_idx": {
+          "name": "tournaments_activity_id_idx",
+          "columns": [
+            {
+              "expression": "activity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "tournaments_game_id_games_id_fk": {
+          "name": "tournaments_game_id_games_id_fk",
+          "tableFrom": "tournaments",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "tableTo": "games",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tournaments_created_by_user_id_users_user_id_fk": {
+          "name": "tournaments_created_by_user_id_users_user_id_fk",
+          "tableFrom": "tournaments",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "tournaments_owner_users_user_id_fk": {
+          "name": "tournaments_owner_users_user_id_fk",
+          "tableFrom": "tournaments",
+          "columnsFrom": [
+            "owner"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_event_fields": {
+      "name": "user_event_fields",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_field_id": {
+          "name": "event_field_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "uef_event_id_idx": {
+          "name": "uef_event_id_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uef_event_field_id_idx": {
+          "name": "uef_event_field_id_idx",
+          "columns": [
+            {
+              "expression": "event_field_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uef_user_id_idx": {
+          "name": "uef_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uef_completed_idx": {
+          "name": "uef_completed_idx",
+          "columns": [
+            {
+              "expression": "completed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uef_created_at_idx": {
+          "name": "uef_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "uef_updated_at_idx": {
+          "name": "uef_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_event_fields_event_field_id_event_fields_id_fk": {
+          "name": "user_event_fields_event_field_id_event_fields_id_fk",
+          "tableFrom": "user_event_fields",
+          "columnsFrom": [
+            "event_field_id"
+          ],
+          "tableTo": "event_fields",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_event_fields_event_id_events_event_id_fk": {
+          "name": "user_event_fields_event_id_events_event_id_fk",
+          "tableFrom": "user_event_fields",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "user_event_fields_user_id_users_user_id_fk": {
+          "name": "user_event_fields_user_id_users_user_id_fk",
+          "tableFrom": "user_event_fields",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_event_fields_event_field_id_user_id_unique": {
+          "name": "user_event_fields_event_field_id_user_id_unique",
+          "columns": [
+            "event_field_id",
+            "user_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.user_roles": {
+      "name": "user_roles",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "access_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_role_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "user_roles_item_id_item_type_idx": {
+          "name": "user_roles_item_id_item_type_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_roles_user_id_idx": {
+          "name": "user_roles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "user_roles_item_id_item_type_user_id_role_pk": {
+          "name": "user_roles_item_id_item_type_user_id_role_pk",
+          "columns": [
+            "item_id",
+            "item_type",
+            "user_id",
+            "role"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.user_score_rules": {
+      "name": "user_score_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "subject_user_id": {
+          "name": "subject_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_role": {
+          "name": "subject_role",
+          "type": "score_rule_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "users_score_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "user_score_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usr_score_rules_match_idx": {
+          "name": "usr_score_rules_match_idx",
+          "columns": [
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "subject_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_score_rules_subject_user_id_users_user_id_fk": {
+          "name": "user_score_rules_subject_user_id_users_user_id_fk",
+          "tableFrom": "user_score_rules",
+          "columnsFrom": [
+            "subject_user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_score_snapshot": {
+      "name": "user_score_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshot_runtime": {
+          "name": "snapshot_runtime",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "free_online_event": {
+          "name": "free_online_event",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "free_offline_event": {
+          "name": "free_offline_event",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "paid_online_event": {
+          "name": "paid_online_event",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "paid_offline_event": {
+          "name": "paid_offline_event",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "join_onton": {
+          "name": "join_onton",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "join_onton_affiliate": {
+          "name": "join_onton_affiliate",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "free_play2win": {
+          "name": "free_play2win",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "paid_play2win": {
+          "name": "paid_play2win",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "claim_status": {
+          "name": "claim_status",
+          "type": "claim_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_claimed'"
+        },
+        "total_score": {
+          "name": "total_score",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_score_snapshot_user_runtime_idx": {
+          "name": "user_score_snapshot_user_runtime_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshot_runtime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_score_snapshot_user_id_idx": {
+          "name": "user_score_snapshot_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_score_snapshot_runtime_idx": {
+          "name": "user_score_snapshot_runtime_idx",
+          "columns": [
+            {
+              "expression": "snapshot_runtime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_score_snapshot_user_id_users_user_id_fk": {
+          "name": "user_score_snapshot_user_id_users_user_id_fk",
+          "tableFrom": "user_score_snapshot",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.user_wallet_balances": {
+      "name": "user_wallet_balances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "place_of_connection": {
+          "name": "place_of_connection",
+          "type": "campaign_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_balance": {
+          "name": "last_balance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "last_checked_at_idx": {
+          "name": "last_checked_at_idx",
+          "columns": [
+            {
+              "expression": "last_checked_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "user_wallet_balances_wallet_address_idx": {
+          "name": "user_wallet_balances_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_wallet_balances_user_id_users_user_id_fk": {
+          "name": "user_wallet_balances_user_id_users_user_id_fk",
+          "tableFrom": "user_wallet_balances",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_id_wallet_address_idx": {
+          "name": "user_id_wallet_address_idx",
+          "columns": [
+            "user_id",
+            "wallet_address",
+            "place_of_connection"
+          ],
+          "nullsNotDistinct": false
+        }
+      }
+    },
+    "public.user_custom_flags": {
+      "name": "user_custom_flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_flag": {
+          "name": "user_flag",
+          "type": "user_flags_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_custom_flags_user_id_user_flag_index": {
+          "name": "user_custom_flags_user_id_user_flag_index",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_flag",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "user_custom_flags_user_id_users_user_id_fk": {
+          "name": "user_custom_flags_user_id_users_user_id_fk",
+          "tableFrom": "user_custom_flags",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language_code": {
+          "name": "language_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "is_premium": {
+          "name": "is_premium",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allows_write_to_pm": {
+          "name": "allows_write_to_pm",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "participated_event_count": {
+          "name": "participated_event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hosted_event_count": {
+          "name": "hosted_event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_blocked_the_bot": {
+          "name": "has_blocked_the_bot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_channel_name": {
+          "name": "org_channel_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_support_telegram_user_name": {
+          "name": "org_support_telegram_user_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_x_link": {
+          "name": "org_x_link",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_bio": {
+          "name": "org_bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_image": {
+          "name": "org_image",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_point": {
+          "name": "user_point",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "affiliator_user_id": {
+          "name": "affiliator_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_username_idx": {
+          "name": "users_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_wallet_address_idx": {
+          "name": "users_wallet_address_idx",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_role_idx": {
+          "name": "users_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_created_at_idx": {
+          "name": "users_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_updated_at_idx": {
+          "name": "users_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_is_premium_idx": {
+          "name": "users_is_premium_idx",
+          "columns": [
+            {
+              "expression": "is_premium",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_hosted_event_count_idx": {
+          "name": "users_hosted_event_count_idx",
+          "columns": [
+            {
+              "expression": "hosted_event_count",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_org_channel_name_idx": {
+          "name": "users_org_channel_name_idx",
+          "columns": [
+            {
+              "expression": "org_channel_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users_score": {
+      "name": "users_score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "users_score_activity_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "point": {
+          "name": "point",
+          "type": "numeric(20, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "user_score_item_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp (6)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_score_user_id_activity_type_active_item_id_item_type_key": {
+          "name": "users_score_user_id_activity_type_active_item_id_item_type_key",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_score_activity_type_idx": {
+          "name": "users_score_activity_type_idx",
+          "columns": [
+            {
+              "expression": "activity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_score_item_id_item_type_idx": {
+          "name": "users_score_item_id_item_type_idx",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "users_score_user_id_idx": {
+          "name": "users_score_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "users_score_user_id_users_user_id_fk": {
+          "name": "users_score_user_id_users_user_id_fk",
+          "tableFrom": "users_score",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.visitors": {
+      "name": "visitors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_uuid": {
+          "name": "event_uuid",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed": {
+          "name": "claimed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tx_hash": {
+          "name": "tx_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_visit": {
+          "name": "last_visit",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'system'"
+        }
+      },
+      "indexes": {
+        "visitors_user_id_idx": {
+          "name": "visitors_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "visitors_event_uuid_idx": {
+          "name": "visitors_event_uuid_idx",
+          "columns": [
+            {
+              "expression": "event_uuid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "visitors_last_visit_idx": {
+          "name": "visitors_last_visit_idx",
+          "columns": [
+            {
+              "expression": "last_visit",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "visitors_created_at_idx": {
+          "name": "visitors_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "visitors_updated_at_idx": {
+          "name": "visitors_updated_at_idx",
+          "columns": [
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "visitors_user_id_users_user_id_fk": {
+          "name": "visitors_user_id_users_user_id_fk",
+          "tableFrom": "visitors",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "users",
+          "columnsTo": [
+            "user_id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "visitors_event_uuid_events_event_uuid_fk": {
+          "name": "visitors_event_uuid_events_event_uuid_fk",
+          "tableFrom": "visitors",
+          "columnsFrom": [
+            "event_uuid"
+          ],
+          "tableTo": "events",
+          "columnsTo": [
+            "event_uuid"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.wallet_checks": {
+      "name": "wallet_checks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "wallet_address": {
+          "name": "wallet_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checked_lt": {
+          "name": "checked_lt",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "wallet_checks_wallet_address_index": {
+          "name": "wallet_checks_wallet_address_index",
+          "columns": [
+            {
+              "expression": "wallet_address",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.access_role": {
+      "name": "access_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "checkin_officer"
+      ]
+    },
+    "public.item_type": {
+      "name": "item_type",
+      "schema": "public",
+      "values": [
+        "event"
+      ]
+    },
+    "public.affiliate_item_type": {
+      "name": "affiliate_item_type",
+      "schema": "public",
+      "values": [
+        "EVENT",
+        "HOME",
+        "onion1-campaign",
+        "onion1-special-affiliations",
+        "onton-join-task"
+      ]
+    },
+    "public.campaign_type": {
+      "name": "campaign_type",
+      "schema": "public",
+      "values": [
+        "campaign",
+        "event",
+        "sbt",
+        "just_connected",
+        "nft_mint",
+        "event_creation",
+        "event_capacity_increment",
+        "promote_to_organizer",
+        "ts_csbt_ticket"
+      ]
+    },
+    "public.claim_status": {
+      "name": "claim_status",
+      "schema": "public",
+      "values": [
+        "not_claimed",
+        "claimed"
+      ]
+    },
+    "public.message_send_status": {
+      "name": "message_send_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed"
+      ]
+    },
+    "public.coupon_definition_status": {
+      "name": "coupon_definition_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive",
+        "expired"
+      ]
+    },
+    "public.coupon_definition_type": {
+      "name": "coupon_definition_type",
+      "schema": "public",
+      "values": [
+        "percent",
+        "fixed"
+      ]
+    },
+    "public.coupon_item_status": {
+      "name": "coupon_item_status",
+      "schema": "public",
+      "values": [
+        "used",
+        "unused"
+      ]
+    },
+    "public.development_environment": {
+      "name": "development_environment",
+      "schema": "public",
+      "values": [
+        "local",
+        "development",
+        "staging",
+        "production"
+      ]
+    },
+    "public.event_participation_type": {
+      "name": "event_participation_type",
+      "schema": "public",
+      "values": [
+        "in_person",
+        "online"
+      ]
+    },
+    "public.event_poa_result_status": {
+      "name": "event_poa_result_status",
+      "schema": "public",
+      "values": [
+        "REPLIED",
+        "EXPIRED"
+      ]
+    },
+    "public.registrant_status": {
+      "name": "registrant_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "rejected",
+        "approved",
+        "checkedin"
+      ]
+    },
+    "public.event_trigger_status": {
+      "name": "event_trigger_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "deactive",
+        "completed",
+        "sending"
+      ]
+    },
+    "public.event_trigger_type": {
+      "name": "event_trigger_type",
+      "schema": "public",
+      "values": [
+        "simple",
+        "multiple_choice",
+        "question",
+        "password"
+      ]
+    },
+    "public.merge_status": {
+      "name": "merge_status",
+      "schema": "public",
+      "values": [
+        "not_allowed_to_merge",
+        "able_to_merge",
+        "waiting_for_transaction",
+        "merging",
+        "merged",
+        "burned"
+      ]
+    },
+    "public.nft_status_enum": {
+      "name": "nft_status_enum",
+      "schema": "public",
+      "values": [
+        "CREATING",
+        "MINTING",
+        "VALIDATION_FAILED",
+        "COMPLETED",
+        "FAILED"
+      ]
+    },
+    "public.notification_item_type": {
+      "name": "notification_item_type",
+      "schema": "public",
+      "values": [
+        "POA_TRIGGER",
+        "EVENT",
+        "SBT_REWARD",
+        "TRANSACTION",
+        "UNKNOWN"
+      ]
+    },
+    "public.notification_status": {
+      "name": "notification_status",
+      "schema": "public",
+      "values": [
+        "WAITING_TO_SEND",
+        "DELIVERED",
+        "READ",
+        "REPLIED",
+        "EXPIRED"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "POA_SIMPLE",
+        "POA_PASSWORD",
+        "POA_CREATION_FOR_ORGANIZER",
+        "USER_RECEIVED_POA",
+        "USER_ANSWER_POA",
+        "MESSAGE_SIMPLE",
+        "UNKNOWN"
+      ]
+    },
+    "public.order_state": {
+      "name": "order_state",
+      "schema": "public",
+      "values": [
+        "new",
+        "confirming",
+        "processing",
+        "completed",
+        "cancelled",
+        "failed"
+      ]
+    },
+    "public.order_types": {
+      "name": "order_types",
+      "schema": "public",
+      "values": [
+        "nft_mint",
+        "event_creation",
+        "event_capacity_increment",
+        "promote_to_organizer",
+        "ts_csbt_ticket"
+      ]
+    },
+    "public.organizer_payment_status": {
+      "name": "organizer_payment_status",
+      "schema": "public",
+      "values": [
+        "not_payed",
+        "payed_to_organizer",
+        "refunded"
+      ]
+    },
+    "public.payment_types": {
+      "name": "payment_types",
+      "schema": "public",
+      "values": [
+        "USDT",
+        "TON",
+        "STAR"
+      ]
+    },
+    "public.ticket_types": {
+      "name": "ticket_types",
+      "schema": "public",
+      "values": [
+        "NFT",
+        "TSCSBT"
+      ]
+    },
+    "public.play2win_campaign_type": {
+      "name": "play2win_campaign_type",
+      "schema": "public",
+      "values": [
+        "genesis_onion"
+      ]
+    },
+    "public.reward_status": {
+      "name": "reward_status",
+      "schema": "public",
+      "values": [
+        "pending_creation",
+        "created",
+        "created_by_ui",
+        "received",
+        "notified",
+        "notified_by_ui",
+        "notification_failed",
+        "failed",
+        "fixed_failed"
+      ]
+    },
+    "public.reward_types": {
+      "name": "reward_types",
+      "schema": "public",
+      "values": [
+        "ton_society_sbt",
+        "ton_society_csbt_ticket"
+      ]
+    },
+    "public.score_rule_role": {
+      "name": "score_rule_role",
+      "schema": "public",
+      "values": [
+        "organizer",
+        "user"
+      ]
+    },
+    "public.task_period": {
+      "name": "task_period",
+      "schema": "public",
+      "values": [
+        "none",
+        "daily",
+        "weekly",
+        "monthly",
+        "yearly",
+        "custom"
+      ]
+    },
+    "public.task_user_sbt_status": {
+      "name": "task_user_sbt_status",
+      "schema": "public",
+      "values": [
+        "has_not_sbt",
+        "pending_creation",
+        "failed",
+        "created",
+        "notified",
+        "given"
+      ]
+    },
+    "public.task_type": {
+      "name": "task_type",
+      "schema": "public",
+      "values": [
+        "affiliation",
+        "join_channel",
+        "join_group",
+        "x_follow",
+        "become_organizer",
+        "watch_video",
+        "buy_ticket",
+        "play_a_tournament",
+        "buy_token",
+        "join_onton"
+      ]
+    },
+    "public.task_user_point_status": {
+      "name": "task_user_point_status",
+      "schema": "public",
+      "values": [
+        "not_allocated",
+        "allocated"
+      ]
+    },
+    "public.task_user_status": {
+      "name": "task_user_status",
+      "schema": "public",
+      "values": [
+        "need_to_check",
+        "in_progress",
+        "done",
+        "failed"
+      ]
+    },
+    "public.event_ticket_status": {
+      "name": "event_ticket_status",
+      "schema": "public",
+      "values": [
+        "USED",
+        "UNUSED"
+      ]
+    },
+    "public.status": {
+      "name": "status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "failed"
+      ]
+    },
+    "public.spin_type": {
+      "name": "spin_type",
+      "schema": "public",
+      "values": [
+        "normal",
+        "specific_reward",
+        "rewarded_spin"
+      ]
+    },
+    "public.user_role_status": {
+      "name": "user_role_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "deactivate"
+      ]
+    },
+    "public.user_score_item_type": {
+      "name": "user_score_item_type",
+      "schema": "public",
+      "values": [
+        "event",
+        "task",
+        "organize_event",
+        "game"
+      ]
+    },
+    "public.user_flags_enum": {
+      "name": "user_flags_enum",
+      "schema": "public",
+      "values": [
+        "event_moderator",
+        "ton_society_verified",
+        "api_key",
+        "custom_registration_1"
+      ]
+    },
+    "public.users_score_activity_type": {
+      "name": "users_score_activity_type",
+      "schema": "public",
+      "values": [
+        "free_online_event",
+        "free_offline_event",
+        "paid_online_event",
+        "paid_offline_event",
+        "join_onton",
+        "join_onton_affiliate",
+        "free_play2win",
+        "paid_play2win"
+      ]
+    },
+    "public.wallet_type": {
+      "name": "wallet_type",
+      "schema": "public",
+      "values": [
+        "primary",
+        "secondary"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/mini-app/drizzle/meta/_journal.json
+++ b/mini-app/drizzle/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1749683684175,
       "tag": "0094_green_silver_fox",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1749727113210,
+      "tag": "0095_regular_garia",
+      "breakpoints": true
     }
   ]
 }

--- a/telegram-bot/src/composers/broadcast.ts
+++ b/telegram-bot/src/composers/broadcast.ts
@@ -1,40 +1,36 @@
-import { Composer, InlineKeyboard, InputFile } from "grammy";
+import { Composer, InlineKeyboard } from "grammy";
 import { MyContext } from "../types/MyContext";
 import {
   isUserAdmin,
   getEvent,
   getEventTickets,
-  getOrCreateSingleInviteLinkForUserAndChat
+  getOrCreateSingleInviteLinkForUserAndChat,
 } from "../db/db";
+import {
+  createBroadcastMessage,
+  bulkInsertBroadcastUsers,
+} from "../db/broadcast";
 import { parse } from "csv-parse/sync";
 import axios from "axios";
 import { isNewCommand } from "../helpers/isNewCommand";
 import { logger } from "../utils/logger";
 import {
   checkBotIsAdmin,
-  escapeCsv,
   extractInviteChatIds,
-  generateBroadcastGroupTitle,
-  normalizeDashes,
-  sleep
 } from "../utils/utils";
-import { additionalRecipients, AFFILIATE_PLACEHOLDERS, INVITE_PLACEHOLDER_REGEX } from "../constants";
-import { Readable } from "stream";
+import { AFFILIATE_PLACEHOLDERS, INVITE_PLACEHOLDER_REGEX } from "../constants";
 import { getOrCreateSingleAffiliateLink } from "../db/affiliateLinks";
-
 
 export const broadcastComposer = new Composer<MyContext>();
 
-
-
 /* -------------------------------------------------------------------------- */
-/* /broadcast Command => user picks event or CSV                              */
+/* /broadcast – entry                                                         */
 /* -------------------------------------------------------------------------- */
 broadcastComposer.command("broadcast", async (ctx) => {
   const { isAdmin } = await isUserAdmin(ctx.from?.id.toString() || "");
   if (!isAdmin) return;
 
-  // Reset session
+  /* reset wizard state */
   ctx.session.broadcastStep = "chooseTarget";
   ctx.session.broadcastType = undefined;
   ctx.session.broadcastEventUuid = undefined;
@@ -49,19 +45,21 @@ broadcastComposer.command("broadcast", async (ctx) => {
 });
 
 /* -------------------------------------------------------------------------- */
-/* Step => user picks event or CSV                                            */
+/* Callback‑query router                                                      */
 /* -------------------------------------------------------------------------- */
 broadcastComposer.on("callback_query:data", async (ctx, next) => {
   if (ctx.session.broadcastStep !== "chooseTarget") return next();
-  await ctx.answerCallbackQuery();
 
+  await ctx.answerCallbackQuery();
   const choice = ctx.callbackQuery.data;
+
   if (choice === "bc_event") {
     ctx.session.broadcastType = "event";
     ctx.session.broadcastStep = "askEventUuid";
     await ctx.reply("Please send the Event UUID (36 characters).");
     return;
-  } else if (choice === "bc_csv") {
+  }
+  if (choice === "bc_csv") {
     ctx.session.broadcastType = "csv";
     ctx.session.broadcastStep = "askCsv";
     await ctx.reply("Please upload your CSV file now (one user_id per line).");
@@ -70,29 +68,30 @@ broadcastComposer.on("callback_query:data", async (ctx, next) => {
 });
 
 /* -------------------------------------------------------------------------- */
-/* Step => handle event UUID or CSV => then askBroadcast                     */
+/* Message router                                                             */
 /* -------------------------------------------------------------------------- */
 broadcastComposer.on("message", async (ctx, next) => {
   if (isNewCommand(ctx)) {
-    ctx.session = {};
+    ctx.session = {} as any;
     return next();
   }
 
-  const step = ctx.session.broadcastStep;
-
-  if (step === "askEventUuid" && ctx.message?.text) {
-    return handleEventUuid(ctx);
-  } else if (step === "askCsv" && ctx.message?.document) {
-    return handleCsvUpload(ctx);
-  } else if (step === "askBroadcast") {
-    return handleBroadcastMessage(ctx);
+  switch (ctx.session.broadcastStep) {
+    case "askEventUuid":
+      if (ctx.message?.text) return handleEventUuid(ctx);
+      break;
+    case "askCsv":
+      if (ctx.message?.document) return handleCsvUpload(ctx);
+      break;
+    case "askBroadcast":
+      return handleBroadcastMessage(ctx);
   }
 
   return next();
 });
 
 /* -------------------------------------------------------------------------- */
-/* handleEventUuid => fetch participants => store user IDs => askBroadcast   */
+/* Step: Event UUID                                                            */
 /* -------------------------------------------------------------------------- */
 async function handleEventUuid(ctx: MyContext) {
   const uuidCandidate = ctx.message?.text?.trim();
@@ -112,7 +111,7 @@ async function handleEventUuid(ctx: MyContext) {
   const tickets = await getEventTickets(uuidCandidate);
   if (!tickets?.length) {
     await ctx.reply(
-        `No participants found for event "${eventRow.title}". Nothing to broadcast.`
+        `No participants found for event \"${eventRow.title}\". Nothing to broadcast.`,
     );
     ctx.session.broadcastStep = "done";
     return;
@@ -121,16 +120,16 @@ async function handleEventUuid(ctx: MyContext) {
   ctx.session.broadcastEventUuid = uuidCandidate;
   ctx.session.broadcastEventTitle = eventRow.title;
   ctx.session.broadcastUserIds = tickets.map((t) => String(t.user_id));
-
   ctx.session.broadcastStep = "askBroadcast";
+
   await ctx.reply(
-      `✅ Event "${eventRow.title}" found with ${tickets.length} participant(s).\n` +
+      `✅ Event \"${eventRow.title}\" found with ${tickets.length} participant(s).\n` +
       "Now send any message (text, photo, video, etc.) you want to broadcast.",
   );
 }
 
 /* -------------------------------------------------------------------------- */
-/* handleCsvUpload => parse CSV => store user IDs => askBroadcast            */
+/* Step: CSV upload                                                            */
 /* -------------------------------------------------------------------------- */
 async function handleCsvUpload(ctx: MyContext) {
   const doc = ctx.message?.document;
@@ -143,7 +142,6 @@ async function handleCsvUpload(ctx: MyContext) {
     return;
   }
 
-  // Download CSV from Telegram
   const fileInfo = await ctx.api.getFile(doc.file_id);
   if (!fileInfo.file_path) {
     await ctx.reply("Unable to retrieve file path from Telegram.");
@@ -177,7 +175,7 @@ async function handleCsvUpload(ctx: MyContext) {
 }
 
 /* -------------------------------------------------------------------------- */
-/* handleBroadcastMessage => final => send to user IDs, track errors         */
+/* Step: receive the actual message to broadcast                               */
 /* -------------------------------------------------------------------------- */
 async function handleBroadcastMessage(ctx: MyContext) {
   const userIds = ctx.session.broadcastUserIds;
@@ -187,246 +185,52 @@ async function handleBroadcastMessage(ctx: MyContext) {
     return;
   }
 
-  if (ctx.session.broadcastType === "event") {
-    await handleEventBroadcast(ctx, userIds);
-  } else {
-    await handleCsvBroadcastWithPlaceholders(ctx, userIds);
+  /* ------------------------------------------------------------- */
+  /* For CSV broadcasts: validate that the bot is admin in all      */
+  /* chats referenced by {invite:<chatId>} placeholders so the cron */
+  /* won't crash later.                                             */
+  /* ------------------------------------------------------------- */
+  if (ctx.session.broadcastType === "csv") {
+    const msg = ctx.message!;
+    const baseText = msg.text ?? msg.caption ?? "";
+
+    // 1) ensure bot admin rights for every chatID used
+    for (const chatId of extractInviteChatIds(baseText)) {
+      const isAdmin = await checkBotIsAdmin(ctx.api, chatId);
+      if (!isAdmin) {
+        await ctx.reply(
+            `❌ The bot is NOT an admin in chatId=${chatId}.\n` +
+            "Please make the bot admin and restart the process.",
+        );
+        ctx.session.broadcastStep = "done";
+        return;
+      }
+    }
   }
+
+  /* ------------------------------------------------------------- */
+  /* Persist broadcast & recipients                                */
+  /* ------------------------------------------------------------- */
+  const rawText =
+      ctx.message?.text ??
+      ctx.message?.caption ??
+      null;            // photo/video without caption ➜ null
+  const broadcastId = await createBroadcastMessage({
+    broadcaster_id: ctx.from!.id,
+    source_chat_id: ctx.chat!.id,
+    source_message_id: ctx.message!.message_id,
+    broadcast_type: ctx.session.broadcastType as "event" | "csv",
+    event_uuid: ctx.session.broadcastEventUuid ?? null,
+    title: ctx.session.broadcastEventTitle ?? "(custom list)",
+    message_text: rawText, // store the original text for later reference
+  });
+  await bulkInsertBroadcastUsers(broadcastId, userIds);
+
+  /* ------------------------------------------------------------- */
+  await ctx.reply(
+      `✅ Broadcast queued! ${userIds.length} user(s) will receive the message shortly.\n` +
+      "You can safely close Telegram – delivery runs in the background.",
+  );
+
   ctx.session.broadcastStep = "done";
 }
-
-/* -------------------------------------------------------------------------- */
-/* handleEventBroadcast => copyMessage, no placeholders                      */
-/* -------------------------------------------------------------------------- */
-async function handleEventBroadcast(ctx: MyContext, userIds: string[]) {
-  const sourceChatId = ctx.chat?.id;
-  const sourceMessageId = ctx.message?.message_id;
-  if (!sourceChatId || !sourceMessageId) {
-    await ctx.reply("Unable to read the message ID or chat ID. Flow ended.");
-    return;
-  }
-
-  await ctx.reply(`Broadcasting this message to ${userIds.length} users...`);
-
-  const errors: { user_id: string; error: string }[] = [];
-  let successCount = 0;
-
-  for (const userId of userIds) {
-    try {
-      await ctx.api.copyMessage(userId, sourceChatId, sourceMessageId);
-      successCount++;
-    } catch (err) {
-      logger.warn(`Failed to send to user ${userId}: ${err}`);
-      errors.push({ user_id: userId, error: String(err) });
-    }
-    await sleep(100);
-  }
-
-  await finalizeBroadcast(ctx, sourceChatId, sourceMessageId, errors, successCount);
-}
-
-/* -------------------------------------------------------------------------- */
-/* handleCsvBroadcastWithPlaceholders => pre-check => if all ok => broadcast */
-/* -------------------------------------------------------------------------- */
-async function handleCsvBroadcastWithPlaceholders(ctx: MyContext, userIds: string[]) {
-  const msg = ctx.message;
-  const sourceChatId = msg.chat?.id!;
-  const sourceMessageId = msg.message_id;
-
-  // 1) Extract text or caption
-  const isText = Boolean(msg.text);
-  const caption = msg.caption || "";
-  const baseText = isText ? msg.text! : caption;
-
-  // 2) Gather all chat IDs from {invite:<chatId>}
-  const chatIds = extractInviteChatIds(baseText);
-
-  // 3) Check if bot is admin for each chat. If any fail => abort
-  for (const chatId of chatIds) {
-    const isAdmin = await checkBotIsAdmin(ctx.api, chatId);
-    if (!isAdmin) {
-      await ctx.reply(
-          `❌ The bot is NOT an admin in chatId=${chatId}.\n` +
-          "Please make the bot admin and restart the process."
-      );
-      // Clear session
-      ctx.session = {};
-      await ctx.reply("Operation canceled. Your active flow(s) have been cleared.");
-      return;
-    }
-  }
-
-  // 4) All placeholders valid => proceed
-  await ctx.reply(`All placeholders are valid. Now sending to ${userIds.length} users...`);
-  const errors: { user_id: string; error: string }[] = [];
-  let successCount = 0;
-  const broadcastGroupTitle = generateBroadcastGroupTitle();
-
-  const isPhoto = Boolean(msg.photo);
-  const isVideo = Boolean(msg.video);
-
-  for (const userId of userIds) {
-    const userIdNum = parseInt(userId, 10);
-    const replacedText = await replacePlaceholdersAndLinks(
-        baseText,
-        userIdNum,
-        broadcastGroupTitle,
-        ctx
-    );
-    try {
-      if (isText) {
-        await ctx.api.sendMessage(userIdNum, replacedText, { parse_mode: "HTML" });
-      } else if (isPhoto && msg.photo) {
-        const largest = msg.photo[msg.photo.length - 1];
-        await ctx.api.sendPhoto(userIdNum, largest.file_id, {
-          caption: replacedText,
-          parse_mode: "HTML",
-        });
-      } else if (isVideo && msg.video) {
-        await ctx.api.sendVideo(userIdNum, msg.video.file_id, {
-          caption: replacedText,
-          parse_mode: "HTML",
-        });
-      } else {
-        // fallback for other media
-        await ctx.api.copyMessage(userIdNum, sourceChatId, sourceMessageId);
-      }
-      successCount++;
-    } catch (err) {
-      logger.warn(`Failed to send to user ${userId}: ${err}`);
-      errors.push({ user_id: userId, error: String(err) });
-    }
-    await sleep(100);
-  }
-
-  await finalizeBroadcast(ctx, sourceChatId, sourceMessageId, errors, successCount);
-}
-
-/* -------------------------------------------------------------------------- */
-/* finalizeBroadcast => handle summary, CSV, notify admins                   */
-/* -------------------------------------------------------------------------- */
-async function finalizeBroadcast(
-    ctx: MyContext,
-    sourceChatId: number,
-    sourceMsgId: number,
-    errors: { user_id: string; error: string }[],
-    successCount: number,
-) {
-  await ctx.reply(`✅ Broadcast complete. Sent to ${successCount} user(s).`);
-  if (errors.length === 0) {
-    await ctx.reply("No errors occurred during the broadcast!");
-    await notifyAdmins(ctx, sourceChatId, sourceMsgId, null, successCount);
-  } else {
-    const header = "user_id,error";
-    const csvRows = errors.map((e) => `${e.user_id},${escapeCsv(e.error)}`);
-    const finalCsvString = [header, ...csvRows].join("\n");
-
-    const fileName = "broadcast_errors.csv";
-    const fileStream = Readable.from(finalCsvString);
-    const inputFile = new InputFile(fileStream, fileName);
-
-    const docMsg = await ctx.replyWithDocument(inputFile, {
-      caption: `There were ${errors.length} errors. See details in the CSV.`,
-    });
-
-    await notifyAdmins(ctx, sourceChatId, sourceMsgId, docMsg.document?.file_id, successCount);
-  }
-}
-
-/* -------------------------------------------------------------------------- */
-/* notifyAdmins => forward the original broadcast + any error CSV            */
-/* -------------------------------------------------------------------------- */
-async function notifyAdmins(
-    ctx: MyContext,
-    broadcastSourceChatId: number,
-    broadcastSourceMsgId: number,
-    errorCsvFileId: string | null | undefined,
-    successCount: number,
-) {
-  const summaryText = `Broadcast summary:\n- Success count: ${successCount}\n`;
-
-  for (const adminId of additionalRecipients) {
-    try {
-      await ctx.api.copyMessage(adminId, broadcastSourceChatId, broadcastSourceMsgId, {
-        caption: "This was the broadcasted message (original).",
-      });
-    } catch (err) {
-      logger.warn(`Could not forward broadcast to admin ${adminId}: ${err}`);
-    }
-
-    try {
-      await ctx.api.sendMessage(adminId, summaryText);
-    } catch (err) {
-      logger.warn(`Could not send summary to admin ${adminId}: ${err}`);
-    }
-
-    if (errorCsvFileId) {
-      try {
-        await ctx.api.sendDocument(adminId, errorCsvFileId, {
-          caption: "Broadcast encountered errors. See CSV.",
-        });
-      } catch (err) {
-        logger.warn(`Could not send CSV to admin ${adminId}: ${err}`);
-      }
-    }
-  }
-}
-
-/* -------------------------------------------------------------------------- */
-/* replacePlaceholdersAndLinks => merges affiliate placeholders + single-use link from DB */
-/* -------------------------------------------------------------------------- */
-async function replacePlaceholdersAndLinks(
-    baseText: string,
-    userId: number,
-    broadcastGroupTitle: string,
-    ctx: MyContext
-): Promise<string> {
-  // Normalize fancy dashes
-  let newText = normalizeDashes(baseText);
-
-  // 1) handle affiliate placeholders
-  for (const ph of AFFILIATE_PLACEHOLDERS) {
-    if (!newText.includes(ph)) continue;
-    const itemType = ph.replace(/[{}]/g, "");
-    const baseTitle = `broadcast-${itemType}-${userId}`;
-
-    try {
-      const linkRow = await getOrCreateSingleAffiliateLink(
-          userId,
-          itemType,
-          baseTitle,
-          broadcastGroupTitle
-      );
-      const finalLinkUrl = `https://t.me/${process.env.NEXT_PUBLIC_BOT_USERNAME}/event?startapp=campaign-aff-${linkRow.link_hash}`;
-      newText = newText.replace(ph, finalLinkUrl);
-    } catch (err) {
-      logger.error(`Error creating affiliate link for user ${userId}, ph=${ph}: ${err}`);
-      newText = newText.replace(ph, "[LINK_ERROR]");
-    }
-  }
-
-  // 2) handle invite placeholders => we create or reuse single invite link from DB
-  const invites = Array.from(newText.matchAll(INVITE_PLACEHOLDER_REGEX));
-  for (const match of invites) {
-    const fullPlaceholder = match[0]; // e.g. "{invite:-1001234567890}"
-    const chatIdStr = match[1];
-    const chatId = parseInt(chatIdStr, 10);
-
-    try {
-      // We do not call createChatInviteLink directly. Instead:
-      const userInviteLink = await getOrCreateSingleInviteLinkForUserAndChat(
-          ctx.api,
-          userId,
-          chatId
-      );
-      newText = newText.replace(fullPlaceholder, userInviteLink);
-    } catch (err) {
-      logger.warn(`getOrCreateSingleInviteLinkForUserAndChat error userId=${userId} chatId=${chatId}: ${err}`);
-      newText = newText.replace(fullPlaceholder, "[LINK_ERROR]");
-    }
-  }
-
-  return newText;
-}
-
-

--- a/telegram-bot/src/cronJobs/broadcastSenderCron.ts
+++ b/telegram-bot/src/cronJobs/broadcastSenderCron.ts
@@ -1,0 +1,244 @@
+import { Bot, GrammyError } from "grammy";
+import { logger } from "../utils/logger";
+import {
+    fetchPendingBroadcastSends,
+    markBroadcastUserSent,
+    markBroadcastUserFailed,
+    broadcastHasPendingUsers,
+    fetchBroadcastErrors,
+    countBroadcastSuccess,
+    getBroadcastMeta,
+} from "../db/broadcast";
+import { Readable } from "stream";
+import { InputFile } from "grammy";
+import {additionalRecipients, AFFILIATE_PLACEHOLDERS, INVITE_PLACEHOLDER_REGEX} from "../constants";
+import {escapeCsv, generateBroadcastGroupTitle, normalizeDashes} from "../utils/utils";
+import {getOrCreateSingleInviteLinkForUserAndChat} from "../db/db";
+import {getOrCreateSingleAffiliateLink} from "../db/affiliateLinks";
+function isChatNotFoundError(err: unknown): boolean {
+    if (err instanceof GrammyError) {
+        return err.error_code === 400 && /chat (?:not )?found/i.test(err.description);
+    }
+    return /chat (?:not )?found/i.test(String(err));
+}
+
+/* ------------------------------------------------------------------ */
+/* Placeholder replacement (same logic you had in composer)           */
+/* ------------------------------------------------------------------ */
+async function replacePlaceholdersAndLinks(
+    baseText: string,
+    userId: number,
+    broadcastGroupTitle: string,
+    bot: Bot,
+): Promise<string> {
+    let newText = normalizeDashes(baseText);
+
+    // affiliate placeholders
+    for (const ph of AFFILIATE_PLACEHOLDERS) {
+        if (!newText.includes(ph)) continue;
+        const itemType = ph.replace(/[{}]/g, "");
+        const baseTitle = `broadcast-${itemType}-${userId}`;
+
+        try {
+            const linkRow = await getOrCreateSingleAffiliateLink(
+                userId,
+                itemType,
+                baseTitle,
+                broadcastGroupTitle,
+            );
+            const finalLink =
+                `https://t.me/${process.env.NEXT_PUBLIC_BOT_USERNAME}/event?startapp=campaign-aff-${linkRow.link_hash}`;
+            newText = newText.replace(ph, finalLink);
+        } catch (err) {
+            logger.error(`aff link err for ${userId}: ${err}`);
+            newText = newText.replace(ph, "[LINK_ERROR]");
+        }
+    }
+
+    // invite placeholders
+    const invites = Array.from(newText.matchAll(INVITE_PLACEHOLDER_REGEX));
+    for (const m of invites) {
+        const full = m[0];
+        const chatId = parseInt(m[1], 10);
+        try {
+            const link = await getOrCreateSingleInviteLinkForUserAndChat(
+                bot.api,
+                userId,
+                chatId,
+            );
+            newText = newText.replace(full, link);
+        } catch (err) {
+            logger.warn(`invite link err uid=${userId} chat=${chatId}: ${err}`);
+            newText = newText.replace(full, "[LINK_ERROR]");
+        }
+    }
+
+    return newText;
+}
+/* ------------------------------------------------------------------ */
+/* broadcastSenderCron                                                */
+/* ------------------------------------------------------------------ */
+export async function broadcastSenderCron(bot: Bot) {
+    const rows = await fetchPendingBroadcastSends(100);
+    if (!rows.length) return;
+
+    logger.info(`broadcastSenderCron: processing ${rows.length} rows`);
+
+    for (const row of rows) {
+        const {
+            bu_id,
+            user_id,
+            retry_count,
+            broadcast_id,
+            broadcast_type,
+            source_chat_id,
+            source_message_id,
+            message_text,          // now available
+        } = row;
+
+        try {
+            let sentMessageId: number;
+
+            if (broadcast_type === "event") {
+                /* no placeholders – cheap copyMessage */
+                const msg = await bot.api.copyMessage(
+                    user_id,
+                    source_chat_id,
+                    source_message_id,
+                );
+                sentMessageId = msg.message_id;
+
+            } else {
+                /* -------------- CSV / placeholders branch ------------------ */
+                const baseText = message_text ?? "";
+                const replaced = await replacePlaceholdersAndLinks(
+                    baseText,
+                    Number(user_id),
+                    generateBroadcastGroupTitle(),
+                    bot,
+                );
+
+                if (!baseText) {
+                    /* text-less media – copy + edit caption */
+                    const copy = await bot.api.copyMessage(
+                        user_id,
+                        source_chat_id,
+                        source_message_id,
+                    );
+                    sentMessageId = copy.message_id;
+                    try {
+                        // first try caption
+                        await bot.api.editMessageCaption(
+                            user_id,                 // chat_id
+                            sentMessageId,           // message_id
+                            {                        // other  (3rd param)
+                                caption: replaced,
+                                parse_mode: "HTML",
+                            },
+                        );
+                    } catch {
+                        // if not a media message with caption, fall back to editing text
+                        await bot.api.editMessageText(user_id, sentMessageId, replaced, {
+                            parse_mode: "HTML",
+                        });
+                    }
+                } else {
+                    /* plain text (or media caption stored as text) */
+                    const msg = await bot.api.sendMessage(user_id, replaced, {
+                        parse_mode: "HTML",
+                    });
+                    sentMessageId = msg.message_id;
+                }
+            }
+
+            await markBroadcastUserSent(bu_id, sentMessageId);
+        } catch (err) {
+            logger.warn(`broadcastSenderCron: error to ${user_id}: ${err}`);
+
+            const fatal =
+                isForbiddenError(err) ||
+                isChatNotFoundError(err) ||
+                retry_count + 1 >= 10;
+
+            await markBroadcastUserFailed(
+                bu_id,
+                retry_count + 1,
+                String(err),
+                fatal,
+            );
+        }
+
+        await delay(100); // 10 msgs/sec
+    }
+    /* ---------------------------------------------------------------- */
+    /* For every broadcast we touched, check if it is now finished       */
+    /* ---------------------------------------------------------------- */
+    const finishedIds = new Set<number>(rows.map((r) => r.broadcast_id));
+
+    for (const bid of Array.from(finishedIds)) {
+        if (await broadcastHasPendingUsers(bid)) continue;   // still work left
+        await notifyAdminsAboutFinishedBroadcast(bot, bid);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* final report to admins                                             */
+/* ------------------------------------------------------------------ */
+async function notifyAdminsAboutFinishedBroadcast(bot: Bot, broadcastId: number) {
+    const { source_chat_id, source_message_id } = await getBroadcastMeta(
+        broadcastId,
+    );
+    const successCount = await countBroadcastSuccess(broadcastId);
+    const errors = await fetchBroadcastErrors(broadcastId);
+
+    const summary = `Broadcast #${broadcastId} finished.\n- Success: ${successCount}\n- Errors: ${errors.length}`;
+
+    /* 1) forward original message */
+    for (const adminId of additionalRecipients) {
+        try {
+            await bot.api.copyMessage(adminId, source_chat_id, source_message_id, {
+                caption: "Original broadcasted message.",
+            });
+        } catch (e) {
+            logger.warn(`notifyAdmins: cannot fwd to ${adminId}: ${e}`);
+        }
+
+        try {
+            await bot.api.sendMessage(adminId, summary);
+        } catch (e) {
+            logger.warn(`notifyAdmins: cannot send summary to ${adminId}: ${e}`);
+        }
+
+        if (!errors.length) continue;
+
+        /* 2) CSV with errors */
+        const csvStr =
+            ["user_id,error", ...errors.map((e) => `${e.user_id},${escapeCsv(e.last_error)}`)].join(
+                "\n",
+            );
+        const stream = Readable.from(csvStr);
+        const csvFile = new InputFile(stream, "broadcast_errors.csv");
+
+        try {
+            await bot.api.sendDocument(adminId, csvFile, {
+                caption: "Broadcast encountered errors. See CSV.",
+            });
+        } catch (e) {
+            logger.warn(`notifyAdmins: cannot send CSV to ${adminId}: ${e}`);
+        }
+    }
+
+    logger.info(`broadcastSenderCron: notified admins about #${broadcastId}`);
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers                                                            */
+/* ------------------------------------------------------------------ */
+function isForbiddenError(err: unknown) {
+    if (err instanceof GrammyError) return err.error_code === 403;
+    return String(err).includes("403");
+}
+
+function delay(ms: number) {
+    return new Promise<void>((res) => setTimeout(res, ms));
+}

--- a/telegram-bot/src/cronJobs/initializer.ts
+++ b/telegram-bot/src/cronJobs/initializer.ts
@@ -1,6 +1,7 @@
 import { CronJob } from "cron";
 import { pollSenderCron } from "./pollSenderCron";
-import { bot } from "../main"; // or wherever your bot is exported
+import { bot } from "../main";
+import {broadcastSenderCron} from "./broadcastSenderCron"; // or wherever your bot is exported
 
 export function startPollSenderCron() {
     // “*/2 * * * *” means “every 2 minutes”
@@ -10,6 +11,22 @@ export function startPollSenderCron() {
             // The function that will be run every 2 minutes
             // waitForCompletion: true => do not start a new run if the previous hasn’t finished
             await pollSenderCron(bot);
+        },
+        null, // onComplete
+        true, // start now
+        undefined, // timezone
+        undefined, // context
+        false, // runOnInit
+        undefined, // utcOffset
+        false, // unrefTimeout
+        true // waitForCompletion
+    );
+    new CronJob(
+        "*/10 * * * * *",
+        async () => {
+            // The function that will be run every 2 minutes
+            // waitForCompletion: true => do not start a new run if the previous hasn’t finished
+            await broadcastSenderCron(bot);
         },
         null, // onComplete
         true, // start now

--- a/telegram-bot/src/db/broadcast.ts
+++ b/telegram-bot/src/db/broadcast.ts
@@ -1,0 +1,215 @@
+import { pool } from "./pool";
+
+/* ---------- types ---------- */
+export interface BroadcastMessageRow {
+    broadcast_id: number;
+    broadcaster_id: number;
+    source_chat_id: number;
+    source_message_id: number;
+    broadcast_type: "event" | "csv";
+    event_uuid?: string | null;
+    title?: string | null;
+    created_at: string;          // ISO
+}
+export interface BroadcastMessageInsert {
+    broadcaster_id: number;
+    source_chat_id: number;
+    source_message_id: number;
+    broadcast_type: "event" | "csv";
+    event_uuid?: string | null;
+    title?: string | null;
+    message_text?: string | null;   // ⬅️ new
+}
+export type SendStatus = "pending" | "sent" | "failed";
+
+/* ---------- inserts ---------- */
+export async function createBroadcastMessage(data: BroadcastMessageInsert) {
+    const {
+        broadcaster_id,
+        source_chat_id,
+        source_message_id,
+        broadcast_type,
+        event_uuid,
+        title,
+        message_text,
+    } = data;
+
+    const res = await pool.query(
+        `INSERT INTO broadcast_messages
+       (broadcaster_id, source_chat_id, source_message_id,
+        broadcast_type, event_uuid, title, message_text)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)
+     RETURNING broadcast_id`,
+        [
+            broadcaster_id,
+            source_chat_id,
+            source_message_id,
+            broadcast_type,
+            event_uuid,
+            title,
+            message_text,
+        ],
+    );
+    return res.rows[0].broadcast_id as number;
+}
+
+export async function bulkInsertBroadcastUsers(
+    broadcastId: number,
+    userIds: string[]
+): Promise<void> {
+    if (!userIds.length) return;
+
+    // Build VALUES ($1,$2),($1,$3)…  (1st param repeated broadcastId)
+    const values: string[] = [];
+    const params: any[] = [];
+    userIds.forEach((uid, i) => {
+        values.push(`($1,$${i + 2})`);
+        params.push(uid);
+    });
+    params.unshift(broadcastId); // $1
+
+    const sql = `
+      INSERT INTO broadcast_users (broadcast_id, user_id)
+      VALUES ${values.join(",")}
+  `;
+    await pool.query(sql, params);
+}
+
+/* ---------- status updates ---------- */
+export async function markUserStatus(
+    id: number,
+    status: SendStatus,
+    error?: string,
+) {
+    const sql = `
+        UPDATE broadcast_users
+        SET send_status = $2::broadcast_send_status,
+            last_error  = $3,
+            sent_at     = CASE WHEN $2::broadcast_send_status = 'sent' THEN now() ELSE NULL END
+        WHERE id = $1
+    `;
+    await pool.query(sql, [id, status, error ?? null]);
+}
+
+/* ---------- fetch helpers ---------- */
+export async function fetchUsersForBroadcast(
+    broadcastId: number
+): Promise<{ id: number; user_id: string }[]> {
+    const sql = `
+      SELECT id, user_id
+      FROM broadcast_users
+      WHERE broadcast_id = $1
+        AND send_status  = 'pending'
+  `;
+    const res = await pool.query(sql, [broadcastId]);
+    return res.rows;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* fetch rows needing work                                             */
+/* ------------------------------------------------------------------ */
+export async function fetchPendingBroadcastSends(limit = 100) {
+    const sql = `
+      SELECT
+        u.id                  AS bu_id,
+        u.user_id,
+        u.retry_count,
+        m.broadcast_id,
+        m.broadcast_type,
+        m.source_chat_id,
+        m.source_message_id,
+        m.message_text
+        
+      FROM broadcast_users u
+      JOIN broadcast_messages m USING (broadcast_id)
+      WHERE u.send_status = 'pending'
+        AND u.retry_count < 10
+      ORDER BY u.id
+      LIMIT $1
+  `;
+    const res = await pool.query(sql, [limit]);
+    return res.rows;
+}
+
+/* ------------------------------------------------------------------ */
+/* status updates                                                      */
+/* ------------------------------------------------------------------ */
+export async function markBroadcastUserSent(
+    buId: number,
+    sentMessageId: number,
+) {
+    await pool.query(
+        `UPDATE broadcast_users
+       SET send_status = 'sent',
+           sent_at     = NOW(),
+           sent_message_id = $2
+     WHERE id = $1`,
+        [buId, sentMessageId],
+    );
+}
+
+export async function markBroadcastUserFailed(
+    buId: number,
+    retry: number,
+    error?: string,
+    final = false,
+) {
+    const status = final ? 'failed' : 'pending';
+    await pool.query(
+        `UPDATE broadcast_users
+       SET retry_count = $2,
+           send_status = $3::broadcast_send_status,
+           last_error  = $4
+     WHERE id = $1`,
+        [buId, retry, status, error ?? null],
+    );
+}
+
+/* ------------------------------------------------------------------ */
+/* helpers for finishing a broadcast                                  */
+/* ------------------------------------------------------------------ */
+export async function broadcastHasPendingUsers(broadcastId: number): Promise<boolean> {
+    const { rows } = await pool.query(
+        `SELECT 1
+       FROM broadcast_users
+      WHERE broadcast_id = $1
+        AND send_status = 'pending'
+      LIMIT 1`,
+        [broadcastId],
+    );
+    return rows.length > 0;
+}
+
+export async function fetchBroadcastErrors(broadcastId: number) {
+    const { rows } = await pool.query(
+        `SELECT user_id, last_error
+       FROM broadcast_users
+      WHERE broadcast_id = $1
+        AND send_status = 'failed'`,
+        [broadcastId],
+    );
+    return rows;
+}
+
+export async function countBroadcastSuccess(broadcastId: number): Promise<number> {
+    const { rows } = await pool.query(
+        `SELECT COUNT(*)::int AS cnt
+       FROM broadcast_users
+      WHERE broadcast_id = $1
+        AND send_status = 'sent'`,
+        [broadcastId],
+    );
+    return rows[0].cnt;
+}
+
+export async function getBroadcastMeta(broadcastId: number) {
+    const { rows } = await pool.query(
+        `SELECT source_chat_id, source_message_id
+       FROM broadcast_messages
+      WHERE broadcast_id = $1`,
+        [broadcastId],
+    );
+    return rows[0];
+}
+


### PR DESCRIPTION
This pull request introduces a new broadcasting feature in the Telegram bot, which includes database schema changes, backend logic updates, and code refactoring to enhance maintainability. The changes primarily focus on implementing a structured broadcast system with reusable components and improved flow handling.

### Database Schema Enhancements:
* Added two new reusable enums: `broadcast_send_status` and `broadcast_delivery_status` for tracking message send and delivery statuses.
* Created `broadcast_messages` and `broadcast_users` tables to store broadcast metadata and recipient details, respectively. Added columns for retry count, sent message ID, and message text.
* Introduced indexes for efficient querying of broadcast data, including a composite index on `broadcast_users` for pending messages.

### Backend Logic Updates:
* Implemented functions `createBroadcastMessage` and `bulkInsertBroadcastUsers` to persist broadcast metadata and recipient details into the database.
* Replaced the previous broadcast handling logic with a more modular approach, queuing messages for background delivery instead of synchronous processing.

### Code Refactoring:
* Refactored the `/broadcast` command flow to use a switch-case structure for better readability and maintainability.
* Removed redundant functions like `handleEventBroadcast`, `handleCsvBroadcastWithPlaceholders`, and `finalizeBroadcast`, centralizing the logic into a streamlined process.
* Simplified placeholder validation and bot admin checks for CSV-based broadcasts.

### Migration Metadata:
* Updated `_journal.json` to include metadata for the new migration script `0095_regular_garia`.