### PR TITLE
Staging

### DIFF
--- a/telegram-bot/src/cronJobs/broadcastSenderCron.ts
+++ b/telegram-bot/src/cronJobs/broadcastSenderCron.ts
@@ -152,6 +152,9 @@ export async function broadcastSenderCron(bot: Bot) {
             }
 
             await markBroadcastUserSent(bu_id, sentMessageId);
+            logger.info(
+                `broadcastSenderCron: sent to ${user_id} (bu_id=${bu_id}, bid=${broadcast_id})`,
+            );
         } catch (err) {
             logger.warn(`broadcastSenderCron: error to ${user_id}: ${err}`);
 


### PR DESCRIPTION
This pull request adds logging to the `broadcastSenderCron` function to improve traceability of broadcast message deliveries.

Logging improvement:

* [`telegram-bot/src/cronJobs/broadcastSenderCron.ts`](diffhunk://#diff-4e3c8a0c0cfe5ce9c8cdc0fea4851f1b8f62e9996fd63f2099d1bc344934e1b3R155-R157): Added an `info` log to record successful message deliveries, including `user_id`, `bu_id`, and `broadcast_id` for better traceability.